### PR TITLE
chore: 백엔드 자동배포 관심사 분리

### DIFF
--- a/.github/workflows/back-release.yml
+++ b/.github/workflows/back-release.yml
@@ -1,11 +1,13 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Test release CI with gradle
+name: Backend test release CI with gradle
 
 on:
   push:
     branches: [ release ]
+    paths-ignore:
+      - "/front/**"
 
 jobs:
   build:


### PR DESCRIPTION
프론트 yml 파일과 확실한 구분을 위해 이름 변경
paths-ignore 명령을 통해 프론트 배포시 백엔드 배포가 반응하지 않도록 변경