### PR TITLE
feat : 태그 관련 기능 구현 및 리팩토링 

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
@@ -1,0 +1,25 @@
+package gg.babble.babble.controller;
+
+import gg.babble.babble.dto.TagResponse;
+import gg.babble.babble.service.TagService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping(value = "/api/tags")
+@RestController
+public class TagController {
+    private final TagService tagService;
+
+    public TagController(final TagService tagService) {
+        this.tagService = tagService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TagResponse>> getAllTags() {
+        return ResponseEntity.ok(tagService.getAllTags());
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/RoomRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/RoomRequest.java
@@ -17,5 +17,5 @@ public class RoomRequest {
     @Positive(message = "게임 ID는 1보다 큰 수여야 합니다.")
     private Long gameId;
     @NotNull(message = "태그 목록은 Null 일 수 없습니다.")
-    private List<String> tags;
+    private List<TagRequest> tags;
 }

--- a/back/babble/src/main/java/gg/babble/babble/dto/RoomResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/RoomResponse.java
@@ -19,7 +19,7 @@ public class RoomResponse {
     private Long roomId;
     private String createdDate;
     private GameResponse game;
-    private List<String> tags;
+    private List<TagResponse> tags;
 
     public static RoomResponse from(final Room room) {
         return RoomResponse.builder()
@@ -30,9 +30,11 @@ public class RoomResponse {
                 .build();
     }
 
-    private static List<String> tagNames(final List<Tag> tags) {
+    private static List<TagResponse> tagNames(final List<Tag> tags) {
         return tags.stream()
-                .map(Tag::getName)
+                .map(tag -> TagResponse.builder()
+                        .name(tag.getName())
+                        .build())
                 .collect(Collectors.toList());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/dto/TagRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/TagRequest.java
@@ -1,0 +1,16 @@
+package gg.babble.babble.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagRequest {
+
+    @NotNull(message = "태그 이름은 Null 일 수 없습니다.")
+    private String name;
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/TagResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/TagResponse.java
@@ -1,0 +1,21 @@
+package gg.babble.babble.dto;
+
+import gg.babble.babble.domain.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagResponse {
+    private String name;
+
+    public static TagResponse from(final Tag tag) {
+        return TagResponse.builder()
+                .name(tag.getName())
+                .build();
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/service/TagService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/TagService.java
@@ -2,6 +2,7 @@ package gg.babble.babble.service;
 
 import gg.babble.babble.domain.Tag;
 import gg.babble.babble.domain.repository.TagRepository;
+import gg.babble.babble.dto.TagRequest;
 import gg.babble.babble.dto.TagResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import org.springframework.stereotype.Service;
@@ -18,14 +19,14 @@ public class TagService {
         this.tagRepository = tagRepository;
     }
 
-    public Tag findById(String name) {
+    public Tag findById(final String name) {
         return tagRepository.findById(name)
                 .orElseThrow(() -> new BabbleNotFoundException("존재하지 않는 태그입니다."));
     }
 
-    public List<Tag> findById(List<String> names) {
-        return names.stream().
-                map(this::findById)
+    public List<Tag> findById(final List<TagRequest> tagRequests) {
+        return tagRequests.stream()
+                .map(tagRequest -> findById(tagRequest.getName()))
                 .collect(Collectors.toList());
     }
 

--- a/back/babble/src/main/java/gg/babble/babble/service/TagService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/TagService.java
@@ -2,6 +2,7 @@ package gg.babble.babble.service;
 
 import gg.babble.babble.domain.Tag;
 import gg.babble.babble.domain.repository.TagRepository;
+import gg.babble.babble.dto.TagResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +26,13 @@ public class TagService {
     public List<Tag> findById(List<String> names) {
         return names.stream().
                 map(this::findById)
+                .collect(Collectors.toList());
+    }
+
+    public List<TagResponse> getAllTags() {
+        List<Tag> tags = tagRepository.findAll();
+        return tags.stream()
+                .map(TagResponse::from)
                 .collect(Collectors.toList());
     }
 }

--- a/back/babble/src/main/resources/static/docs/api-docs.html
+++ b/back/babble/src/main/resources/static/docs/api-docs.html
@@ -1,2461 +1,717 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <meta content="Asciidoctor 2.0.10" name="generator">
-    <meta content="Wilder&lt;gyuhanKang@gmail.com&gt;" name="author">
-    <title>Babble API Docs</title>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"
-          rel="stylesheet">
-    <style>
-        /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-        /* Uncomment @import statement to use as custom stylesheet */
-        /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-        article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section {
-            display: block
-        }
-
-        audio, video {
-            display: inline-block
-        }
-
-        audio:not([controls]) {
-            display: none;
-            height: 0
-        }
-
-        html {
-            font-family: sans-serif;
-            -ms-text-size-adjust: 100%;
-            -webkit-text-size-adjust: 100%
-        }
-
-        a {
-            background: none
-        }
-
-        a:focus {
-            outline: thin dotted
-        }
-
-        a:active, a:hover {
-            outline: 0
-        }
-
-        h1 {
-            font-size: 2em;
-            margin: .67em 0
-        }
-
-        abbr[title] {
-            border-bottom: 1px dotted
-        }
-
-        b, strong {
-            font-weight: bold
-        }
-
-        dfn {
-            font-style: italic
-        }
-
-        hr {
-            -moz-box-sizing: content-box;
-            box-sizing: content-box;
-            height: 0
-        }
-
-        mark {
-            background: #ff0;
-            color: #000
-        }
-
-        code, kbd, pre, samp {
-            font-family: monospace;
-            font-size: 1em
-        }
-
-        pre {
-            white-space: pre-wrap
-        }
-
-        q {
-            quotes: "\201C" "\201D" "\2018" "\2019"
-        }
-
-        small {
-            font-size: 80%
-        }
-
-        sub, sup {
-            font-size: 75%;
-            line-height: 0;
-            position: relative;
-            vertical-align: baseline
-        }
-
-        sup {
-            top: -.5em
-        }
-
-        sub {
-            bottom: -.25em
-        }
-
-        img {
-            border: 0
-        }
-
-        svg:not(:root) {
-            overflow: hidden
-        }
-
-        figure {
-            margin: 0
-        }
-
-        fieldset {
-            border: 1px solid silver;
-            margin: 0 2px;
-            padding: .35em .625em .75em
-        }
-
-        legend {
-            border: 0;
-            padding: 0
-        }
-
-        button, input, select, textarea {
-            font-family: inherit;
-            font-size: 100%;
-            margin: 0
-        }
-
-        button, input {
-            line-height: normal
-        }
-
-        button, select {
-            text-transform: none
-        }
-
-        button, html input[type="button"], input[type="reset"], input[type="submit"] {
-            -webkit-appearance: button;
-            cursor: pointer
-        }
-
-        button[disabled], html input[disabled] {
-            cursor: default
-        }
-
-        input[type="checkbox"], input[type="radio"] {
-            box-sizing: border-box;
-            padding: 0
-        }
-
-        button::-moz-focus-inner, input::-moz-focus-inner {
-            border: 0;
-            padding: 0
-        }
-
-        textarea {
-            overflow: auto;
-            vertical-align: top
-        }
-
-        table {
-            border-collapse: collapse;
-            border-spacing: 0
-        }
-
-        *, *::before, *::after {
-            -moz-box-sizing: border-box;
-            -webkit-box-sizing: border-box;
-            box-sizing: border-box
-        }
-
-        html, body {
-            font-size: 100%
-        }
-
-        body {
-            background: #fff;
-            color: rgba(0, 0, 0, .8);
-            padding: 0;
-            margin: 0;
-            font-family: "Noto Serif", "DejaVu Serif", serif;
-            font-weight: 400;
-            font-style: normal;
-            line-height: 1;
-            position: relative;
-            cursor: auto;
-            tab-size: 4;
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased
-        }
-
-        a:hover {
-            cursor: pointer
-        }
-
-        img, object, embed {
-            max-width: 100%;
-            height: auto
-        }
-
-        object, embed {
-            height: 100%
-        }
-
-        img {
-            -ms-interpolation-mode: bicubic
-        }
-
-        .left {
-            float: left !important
-        }
-
-        .right {
-            float: right !important
-        }
-
-        .text-left {
-            text-align: left !important
-        }
-
-        .text-right {
-            text-align: right !important
-        }
-
-        .text-center {
-            text-align: center !important
-        }
-
-        .text-justify {
-            text-align: justify !important
-        }
-
-        .hide {
-            display: none
-        }
-
-        img, object, svg {
-            display: inline-block;
-            vertical-align: middle
-        }
-
-        textarea {
-            height: auto;
-            min-height: 50px
-        }
-
-        select {
-            width: 100%
-        }
-
-        .center {
-            margin-left: auto;
-            margin-right: auto
-        }
-
-        .stretch {
-            width: 100%
-        }
-
-        .subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title {
-            line-height: 1.45;
-            color: #7a2518;
-            font-weight: 400;
-            margin-top: 0;
-            margin-bottom: .25em
-        }
-
-        div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td {
-            margin: 0;
-            padding: 0;
-            direction: ltr
-        }
-
-        a {
-            color: #2156a5;
-            text-decoration: underline;
-            line-height: inherit
-        }
-
-        a:hover, a:focus {
-            color: #1d4b8f
-        }
-
-        a img {
-            border: 0
-        }
-
-        p {
-            font-family: inherit;
-            font-weight: 400;
-            font-size: 1em;
-            line-height: 1.6;
-            margin-bottom: 1.25em;
-            text-rendering: optimizeLegibility
-        }
-
-        p aside {
-            font-size: .875em;
-            line-height: 1.35;
-            font-style: italic
-        }
-
-        h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
-            font-family: "Open Sans", "DejaVu Sans", sans-serif;
-            font-weight: 300;
-            font-style: normal;
-            color: #ba3925;
-            text-rendering: optimizeLegibility;
-            margin-top: 1em;
-            margin-bottom: .5em;
-            line-height: 1.0125em
-        }
-
-        h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small {
-            font-size: 60%;
-            color: #e99b8f;
-            line-height: 0
-        }
-
-        h1 {
-            font-size: 2.125em
-        }
-
-        h2 {
-            font-size: 1.6875em
-        }
-
-        h3, #toctitle, .sidebarblock > .content > .title {
-            font-size: 1.375em
-        }
-
-        h4, h5 {
-            font-size: 1.125em
-        }
-
-        h6 {
-            font-size: 1em
-        }
-
-        hr {
-            border: solid #dddddf;
-            border-width: 1px 0 0;
-            clear: both;
-            margin: 1.25em 0 1.1875em;
-            height: 0
-        }
-
-        em, i {
-            font-style: italic;
-            line-height: inherit
-        }
-
-        strong, b {
-            font-weight: bold;
-            line-height: inherit
-        }
-
-        small {
-            font-size: 60%;
-            line-height: inherit
-        }
-
-        code {
-            font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
-            font-weight: 400;
-            color: rgba(0, 0, 0, .9)
-        }
-
-        ul, ol, dl {
-            font-size: 1em;
-            line-height: 1.6;
-            margin-bottom: 1.25em;
-            list-style-position: outside;
-            font-family: inherit
-        }
-
-        ul, ol {
-            margin-left: 1.5em
-        }
-
-        ul li ul, ul li ol {
-            margin-left: 1.25em;
-            margin-bottom: 0;
-            font-size: 1em
-        }
-
-        ul.square li ul, ul.circle li ul, ul.disc li ul {
-            list-style: inherit
-        }
-
-        ul.square {
-            list-style-type: square
-        }
-
-        ul.circle {
-            list-style-type: circle
-        }
-
-        ul.disc {
-            list-style-type: disc
-        }
-
-        ol li ul, ol li ol {
-            margin-left: 1.25em;
-            margin-bottom: 0
-        }
-
-        dl dt {
-            margin-bottom: .3125em;
-            font-weight: bold
-        }
-
-        dl dd {
-            margin-bottom: 1.25em
-        }
-
-        abbr, acronym {
-            text-transform: uppercase;
-            font-size: 90%;
-            color: rgba(0, 0, 0, .8);
-            border-bottom: 1px dotted #ddd;
-            cursor: help
-        }
-
-        abbr {
-            text-transform: none
-        }
-
-        blockquote {
-            margin: 0 0 1.25em;
-            padding: .5625em 1.25em 0 1.1875em;
-            border-left: 1px solid #ddd
-        }
-
-        blockquote cite {
-            display: block;
-            font-size: .9375em;
-            color: rgba(0, 0, 0, .6)
-        }
-
-        blockquote cite::before {
-            content: "\2014 \0020"
-        }
-
-        blockquote cite a, blockquote cite a:visited {
-            color: rgba(0, 0, 0, .6)
-        }
-
-        blockquote, blockquote p {
-            line-height: 1.6;
-            color: rgba(0, 0, 0, .85)
-        }
-
-        @media screen and (min-width: 768px) {
-            h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
-                line-height: 1.2
-            }
-
-            h1 {
-                font-size: 2.75em
-            }
-
-            h2 {
-                font-size: 2.3125em
-            }
-
-            h3, #toctitle, .sidebarblock > .content > .title {
-                font-size: 1.6875em
-            }
-
-            h4 {
-                font-size: 1.4375em
-            }
-        }
-
-        table {
-            background: #fff;
-            margin-bottom: 1.25em;
-            border: solid 1px #dedede
-        }
-
-        table thead, table tfoot {
-            background: #f7f8f7
-        }
-
-        table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td {
-            padding: .5em .625em .625em;
-            font-size: inherit;
-            color: rgba(0, 0, 0, .8);
-            text-align: left
-        }
-
-        table tr th, table tr td {
-            padding: .5625em .625em;
-            font-size: inherit;
-            color: rgba(0, 0, 0, .8)
-        }
-
-        table tr.even, table tr.alt {
-            background: #f8f8f7
-        }
-
-        table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td {
-            display: table-cell;
-            line-height: 1.6
-        }
-
-        h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 {
-            line-height: 1.2;
-            word-spacing: -.05em
-        }
-
-        h1 strong, h2 strong, h3 strong, #toctitle strong, .sidebarblock > .content > .title strong, h4 strong, h5 strong, h6 strong {
-            font-weight: 400
-        }
-
-        .clearfix::before, .clearfix::after, .float-group::before, .float-group::after {
-            content: " ";
-            display: table
-        }
-
-        .clearfix::after, .float-group::after {
-            clear: both
-        }
-
-        :not(pre):not([class^=L]) > code {
-            font-size: .9375em;
-            font-style: normal !important;
-            letter-spacing: 0;
-            padding: .1em .5ex;
-            word-spacing: -.15em;
-            background: #f7f7f8;
-            -webkit-border-radius: 4px;
-            border-radius: 4px;
-            line-height: 1.45;
-            text-rendering: optimizeSpeed;
-            word-wrap: break-word
-        }
-
-        :not(pre) > code.nobreak {
-            word-wrap: normal
-        }
-
-        :not(pre) > code.nowrap {
-            white-space: nowrap
-        }
-
-        pre {
-            color: rgba(0, 0, 0, .9);
-            font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
-            line-height: 1.45;
-            text-rendering: optimizeSpeed
-        }
-
-        pre code, pre pre {
-            color: inherit;
-            font-size: inherit;
-            line-height: inherit
-        }
-
-        pre > code {
-            display: block
-        }
-
-        pre.nowrap, pre.nowrap pre {
-            white-space: pre;
-            word-wrap: normal
-        }
-
-        em em {
-            font-style: normal
-        }
-
-        strong strong {
-            font-weight: 400
-        }
-
-        .keyseq {
-            color: rgba(51, 51, 51, .8)
-        }
-
-        kbd {
-            font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
-            display: inline-block;
-            color: rgba(0, 0, 0, .8);
-            font-size: .65em;
-            line-height: 1.45;
-            background: #f7f7f7;
-            border: 1px solid #ccc;
-            -webkit-border-radius: 3px;
-            border-radius: 3px;
-            -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, .2), 0 0 0 .1em white inset;
-            box-shadow: 0 1px 0 rgba(0, 0, 0, .2), 0 0 0 .1em #fff inset;
-            margin: 0 .15em;
-            padding: .2em .5em;
-            vertical-align: middle;
-            position: relative;
-            top: -.1em;
-            white-space: nowrap
-        }
-
-        .keyseq kbd:first-child {
-            margin-left: 0
-        }
-
-        .keyseq kbd:last-child {
-            margin-right: 0
-        }
-
-        .menuseq, .menuref {
-            color: #000
-        }
-
-        .menuseq b:not(.caret), .menuref {
-            font-weight: inherit
-        }
-
-        .menuseq {
-            word-spacing: -.02em
-        }
-
-        .menuseq b.caret {
-            font-size: 1.25em;
-            line-height: .8
-        }
-
-        .menuseq i.caret {
-            font-weight: bold;
-            text-align: center;
-            width: .45em
-        }
-
-        b.button::before, b.button::after {
-            position: relative;
-            top: -1px;
-            font-weight: 400
-        }
-
-        b.button::before {
-            content: "[";
-            padding: 0 3px 0 2px
-        }
-
-        b.button::after {
-            content: "]";
-            padding: 0 2px 0 3px
-        }
-
-        p a > code:hover {
-            color: rgba(0, 0, 0, .9)
-        }
-
-        #header, #content, #footnotes, #footer {
-            width: 100%;
-            margin-left: auto;
-            margin-right: auto;
-            margin-top: 0;
-            margin-bottom: 0;
-            max-width: 62.5em;
-            *zoom: 1;
-            position: relative;
-            padding-left: .9375em;
-            padding-right: .9375em
-        }
-
-        #header::before, #header::after, #content::before, #content::after, #footnotes::before, #footnotes::after, #footer::before, #footer::after {
-            content: " ";
-            display: table
-        }
-
-        #header::after, #content::after, #footnotes::after, #footer::after {
-            clear: both
-        }
-
-        #content {
-            margin-top: 1.25em
-        }
-
-        #content::before {
-            content: none
-        }
-
-        #header > h1:first-child {
-            color: rgba(0, 0, 0, .85);
-            margin-top: 2.25rem;
-            margin-bottom: 0
-        }
-
-        #header > h1:first-child + #toc {
-            margin-top: 8px;
-            border-top: 1px solid #dddddf
-        }
-
-        #header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) {
-            border-bottom: 1px solid #dddddf;
-            padding-bottom: 8px
-        }
-
-        #header .details {
-            border-bottom: 1px solid #dddddf;
-            line-height: 1.45;
-            padding-top: .25em;
-            padding-bottom: .25em;
-            padding-left: .25em;
-            color: rgba(0, 0, 0, .6);
-            display: -ms-flexbox;
-            display: -webkit-flex;
-            display: flex;
-            -ms-flex-flow: row wrap;
-            -webkit-flex-flow: row wrap;
-            flex-flow: row wrap
-        }
-
-        #header .details span:first-child {
-            margin-left: -.125em
-        }
-
-        #header .details span.email a {
-            color: rgba(0, 0, 0, .85)
-        }
-
-        #header .details br {
-            display: none
-        }
-
-        #header .details br + span::before {
-            content: "\00a0\2013\00a0"
-        }
-
-        #header .details br + span.author::before {
-            content: "\00a0\22c5\00a0";
-            color: rgba(0, 0, 0, .85)
-        }
-
-        #header .details br + span#revremark::before {
-            content: "\00a0|\00a0"
-        }
-
-        #header #revnumber {
-            text-transform: capitalize
-        }
-
-        #header #revnumber::after {
-            content: "\00a0"
-        }
-
-        #content > h1:first-child:not([class]) {
-            color: rgba(0, 0, 0, .85);
-            border-bottom: 1px solid #dddddf;
-            padding-bottom: 8px;
-            margin-top: 0;
-            padding-top: 1rem;
-            margin-bottom: 1.25rem
-        }
-
-        #toc {
-            border-bottom: 1px solid #e7e7e9;
-            padding-bottom: .5em
-        }
-
-        #toc > ul {
-            margin-left: .125em
-        }
-
-        #toc ul.sectlevel0 > li > a {
-            font-style: italic
-        }
-
-        #toc ul.sectlevel0 ul.sectlevel1 {
-            margin: .5em 0
-        }
-
-        #toc ul {
-            font-family: "Open Sans", "DejaVu Sans", sans-serif;
-            list-style-type: none
-        }
-
-        #toc li {
-            line-height: 1.3334;
-            margin-top: .3334em
-        }
-
-        #toc a {
-            text-decoration: none
-        }
-
-        #toc a:active {
-            text-decoration: underline
-        }
-
-        #toctitle {
-            color: #7a2518;
-            font-size: 1.2em
-        }
-
-        @media screen and (min-width: 768px) {
-            #toctitle {
-                font-size: 1.375em
-            }
-
-            body.toc2 {
-                padding-left: 15em;
-                padding-right: 0
-            }
-
-            #toc.toc2 {
-                margin-top: 0 !important;
-                background: #f8f8f7;
-                position: fixed;
-                width: 15em;
-                left: 0;
-                top: 0;
-                border-right: 1px solid #e7e7e9;
-                border-top-width: 0 !important;
-                border-bottom-width: 0 !important;
-                z-index: 1000;
-                padding: 1.25em 1em;
-                height: 100%;
-                overflow: auto
-            }
-
-            #toc.toc2 #toctitle {
-                margin-top: 0;
-                margin-bottom: .8rem;
-                font-size: 1.2em
-            }
-
-            #toc.toc2 > ul {
-                font-size: .9em;
-                margin-bottom: 0
-            }
-
-            #toc.toc2 ul ul {
-                margin-left: 0;
-                padding-left: 1em
-            }
-
-            #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
-                padding-left: 0;
-                margin-top: .5em;
-                margin-bottom: .5em
-            }
-
-            body.toc2.toc-right {
-                padding-left: 0;
-                padding-right: 15em
-            }
-
-            body.toc2.toc-right #toc.toc2 {
-                border-right-width: 0;
-                border-left: 1px solid #e7e7e9;
-                left: auto;
-                right: 0
-            }
-        }
-
-        @media screen and (min-width: 1280px) {
-            body.toc2 {
-                padding-left: 20em;
-                padding-right: 0
-            }
-
-            #toc.toc2 {
-                width: 20em
-            }
-
-            #toc.toc2 #toctitle {
-                font-size: 1.375em
-            }
-
-            #toc.toc2 > ul {
-                font-size: .95em
-            }
-
-            #toc.toc2 ul ul {
-                padding-left: 1.25em
-            }
-
-            body.toc2.toc-right {
-                padding-left: 0;
-                padding-right: 20em
-            }
-        }
-
-        #content #toc {
-            border-style: solid;
-            border-width: 1px;
-            border-color: #e0e0dc;
-            margin-bottom: 1.25em;
-            padding: 1.25em;
-            background: #f8f8f7;
-            -webkit-border-radius: 4px;
-            border-radius: 4px
-        }
-
-        #content #toc > :first-child {
-            margin-top: 0
-        }
-
-        #content #toc > :last-child {
-            margin-bottom: 0
-        }
-
-        #footer {
-            max-width: 100%;
-            background: rgba(0, 0, 0, .8);
-            padding: 1.25em
-        }
-
-        #footer-text {
-            color: rgba(255, 255, 255, .8);
-            line-height: 1.44
-        }
-
-        #content {
-            margin-bottom: .625em
-        }
-
-        .sect1 {
-            padding-bottom: .625em
-        }
-
-        @media screen and (min-width: 768px) {
-            #content {
-                margin-bottom: 1.25em
-            }
-
-            .sect1 {
-                padding-bottom: 1.25em
-            }
-        }
-
-        .sect1:last-child {
-            padding-bottom: 0
-        }
-
-        .sect1 + .sect1 {
-            border-top: 1px solid #e7e7e9
-        }
-
-        #content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor {
-            position: absolute;
-            z-index: 1001;
-            width: 1.5ex;
-            margin-left: -1.5ex;
-            display: block;
-            text-decoration: none !important;
-            visibility: hidden;
-            text-align: center;
-            font-weight: 400
-        }
-
-        #content h1 > a.anchor::before, h2 > a.anchor::before, h3 > a.anchor::before, #toctitle > a.anchor::before, .sidebarblock > .content > .title > a.anchor::before, h4 > a.anchor::before, h5 > a.anchor::before, h6 > a.anchor::before {
-            content: "\00A7";
-            font-size: .85em;
-            display: block;
-            padding-top: .1em
-        }
-
-        #content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover {
-            visibility: visible
-        }
-
-        #content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link {
-            color: #ba3925;
-            text-decoration: none
-        }
-
-        #content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover {
-            color: #a53221
-        }
-
-        details, .audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock {
-            margin-bottom: 1.25em
-        }
-
-        details > summary:first-of-type {
-            cursor: pointer;
-            display: list-item;
-            outline: none;
-            margin-bottom: .75em
-        }
-
-        .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title {
-            text-rendering: optimizeLegibility;
-            text-align: left;
-            font-family: "Noto Serif", "DejaVu Serif", serif;
-            font-size: 1rem;
-            font-style: italic
-        }
-
-        table.tableblock.fit-content > caption.title {
-            white-space: nowrap;
-            width: 0
-        }
-
-        .paragraph.lead > p, #preamble > .sectionbody > [class="paragraph"]:first-of-type p {
-            font-size: 1.21875em;
-            line-height: 1.6;
-            color: rgba(0, 0, 0, .85)
-        }
-
-        table.tableblock #preamble > .sectionbody > [class="paragraph"]:first-of-type p {
-            font-size: inherit
-        }
-
-        .admonitionblock > table {
-            border-collapse: separate;
-            border: 0;
-            background: none;
-            width: 100%
-        }
-
-        .admonitionblock > table td.icon {
-            text-align: center;
-            width: 80px
-        }
-
-        .admonitionblock > table td.icon img {
-            max-width: none
-        }
-
-        .admonitionblock > table td.icon .title {
-            font-weight: bold;
-            font-family: "Open Sans", "DejaVu Sans", sans-serif;
-            text-transform: uppercase
-        }
-
-        .admonitionblock > table td.content {
-            padding-left: 1.125em;
-            padding-right: 1.25em;
-            border-left: 1px solid #dddddf;
-            color: rgba(0, 0, 0, .6)
-        }
-
-        .admonitionblock > table td.content > :last-child > :last-child {
-            margin-bottom: 0
-        }
-
-        .exampleblock > .content {
-            border-style: solid;
-            border-width: 1px;
-            border-color: #e6e6e6;
-            margin-bottom: 1.25em;
-            padding: 1.25em;
-            background: #fff;
-            -webkit-border-radius: 4px;
-            border-radius: 4px
-        }
-
-        .exampleblock > .content > :first-child {
-            margin-top: 0
-        }
-
-        .exampleblock > .content > :last-child {
-            margin-bottom: 0
-        }
-
-        .sidebarblock {
-            border-style: solid;
-            border-width: 1px;
-            border-color: #dbdbd6;
-            margin-bottom: 1.25em;
-            padding: 1.25em;
-            background: #f3f3f2;
-            -webkit-border-radius: 4px;
-            border-radius: 4px
-        }
-
-        .sidebarblock > :first-child {
-            margin-top: 0
-        }
-
-        .sidebarblock > :last-child {
-            margin-bottom: 0
-        }
-
-        .sidebarblock > .content > .title {
-            color: #7a2518;
-            margin-top: 0;
-            text-align: center
-        }
-
-        .exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child {
-            margin-bottom: 0
-        }
-
-        .literalblock pre, .listingblock > .content > pre {
-            -webkit-border-radius: 4px;
-            border-radius: 4px;
-            word-wrap: break-word;
-            overflow-x: auto;
-            padding: 1em;
-            font-size: .8125em
-        }
-
-        @media screen and (min-width: 768px) {
-            .literalblock pre, .listingblock > .content > pre {
-                font-size: .90625em
-            }
-        }
-
-        @media screen and (min-width: 1280px) {
-            .literalblock pre, .listingblock > .content > pre {
-                font-size: 1em
-            }
-        }
-
-        .literalblock pre, .listingblock > .content > pre:not(.highlight), .listingblock > .content > pre[class="highlight"], .listingblock > .content > pre[class^="highlight "] {
-            background: #f7f7f8
-        }
-
-        .literalblock.output pre {
-            color: #f7f7f8;
-            background: rgba(0, 0, 0, .9)
-        }
-
-        .listingblock > .content {
-            position: relative
-        }
-
-        .listingblock code[data-lang]::before {
-            display: none;
-            content: attr(data-lang);
-            position: absolute;
-            font-size: .75em;
-            top: .425rem;
-            right: .5rem;
-            line-height: 1;
-            text-transform: uppercase;
-            color: inherit;
-            opacity: .5
-        }
-
-        .listingblock:hover code[data-lang]::before {
-            display: block
-        }
-
-        .listingblock.terminal pre .command::before {
-            content: attr(data-prompt);
-            padding-right: .5em;
-            color: inherit;
-            opacity: .5
-        }
-
-        .listingblock.terminal pre .command:not([data-prompt])::before {
-            content: "$"
-        }
-
-        .listingblock pre.highlightjs {
-            padding: 0
-        }
-
-        .listingblock pre.highlightjs > code {
-            padding: 1em;
-            -webkit-border-radius: 4px;
-            border-radius: 4px
-        }
-
-        .listingblock pre.prettyprint {
-            border-width: 0
-        }
-
-        .prettyprint {
-            background: #f7f7f8
-        }
-
-        pre.prettyprint .linenums {
-            line-height: 1.45;
-            margin-left: 2em
-        }
-
-        pre.prettyprint li {
-            background: none;
-            list-style-type: inherit;
-            padding-left: 0
-        }
-
-        pre.prettyprint li code[data-lang]::before {
-            opacity: 1
-        }
-
-        pre.prettyprint li:not(:first-child) code[data-lang]::before {
-            display: none
-        }
-
-        table.linenotable {
-            border-collapse: separate;
-            border: 0;
-            margin-bottom: 0;
-            background: none
-        }
-
-        table.linenotable td[class] {
-            color: inherit;
-            vertical-align: top;
-            padding: 0;
-            line-height: inherit;
-            white-space: normal
-        }
-
-        table.linenotable td.code {
-            padding-left: .75em
-        }
-
-        table.linenotable td.linenos {
-            border-right: 1px solid currentColor;
-            opacity: .35;
-            padding-right: .5em
-        }
-
-        pre.pygments .lineno {
-            border-right: 1px solid currentColor;
-            opacity: .35;
-            display: inline-block;
-            margin-right: .75em
-        }
-
-        pre.pygments .lineno::before {
-            content: "";
-            margin-right: -.125em
-        }
-
-        .quoteblock {
-            margin: 0 1em 1.25em 1.5em;
-            display: table
-        }
-
-        .quoteblock:not(.excerpt) > .title {
-            margin-left: -1.5em;
-            margin-bottom: .75em
-        }
-
-        .quoteblock blockquote, .quoteblock p {
-            color: rgba(0, 0, 0, .85);
-            font-size: 1.15rem;
-            line-height: 1.75;
-            word-spacing: .1em;
-            letter-spacing: 0;
-            font-style: italic;
-            text-align: justify
-        }
-
-        .quoteblock blockquote {
-            margin: 0;
-            padding: 0;
-            border: 0
-        }
-
-        .quoteblock blockquote::before {
-            content: "\201c";
-            float: left;
-            font-size: 2.75em;
-            font-weight: bold;
-            line-height: .6em;
-            margin-left: -.6em;
-            color: #7a2518;
-            text-shadow: 0 1px 2px rgba(0, 0, 0, .1)
-        }
-
-        .quoteblock blockquote > .paragraph:last-child p {
-            margin-bottom: 0
-        }
-
-        .quoteblock .attribution {
-            margin-top: .75em;
-            margin-right: .5ex;
-            text-align: right
-        }
-
-        .verseblock {
-            margin: 0 1em 1.25em
-        }
-
-        .verseblock pre {
-            font-family: "Open Sans", "DejaVu Sans", sans;
-            font-size: 1.15rem;
-            color: rgba(0, 0, 0, .85);
-            font-weight: 300;
-            text-rendering: optimizeLegibility
-        }
-
-        .verseblock pre strong {
-            font-weight: 400
-        }
-
-        .verseblock .attribution {
-            margin-top: 1.25rem;
-            margin-left: .5ex
-        }
-
-        .quoteblock .attribution, .verseblock .attribution {
-            font-size: .9375em;
-            line-height: 1.45;
-            font-style: italic
-        }
-
-        .quoteblock .attribution br, .verseblock .attribution br {
-            display: none
-        }
-
-        .quoteblock .attribution cite, .verseblock .attribution cite {
-            display: block;
-            letter-spacing: -.025em;
-            color: rgba(0, 0, 0, .6)
-        }
-
-        .quoteblock.abstract blockquote::before, .quoteblock.excerpt blockquote::before, .quoteblock .quoteblock blockquote::before {
-            display: none
-        }
-
-        .quoteblock.abstract blockquote, .quoteblock.abstract p, .quoteblock.excerpt blockquote, .quoteblock.excerpt p, .quoteblock .quoteblock blockquote, .quoteblock .quoteblock p {
-            line-height: 1.6;
-            word-spacing: 0
-        }
-
-        .quoteblock.abstract {
-            margin: 0 1em 1.25em;
-            display: block
-        }
-
-        .quoteblock.abstract > .title {
-            margin: 0 0 .375em;
-            font-size: 1.15em;
-            text-align: center
-        }
-
-        .quoteblock.excerpt > blockquote, .quoteblock .quoteblock {
-            padding: 0 0 .25em 1em;
-            border-left: .25em solid #dddddf
-        }
-
-        .quoteblock.excerpt, .quoteblock .quoteblock {
-            margin-left: 0
-        }
-
-        .quoteblock.excerpt blockquote, .quoteblock.excerpt p, .quoteblock .quoteblock blockquote, .quoteblock .quoteblock p {
-            color: inherit;
-            font-size: 1.0625rem
-        }
-
-        .quoteblock.excerpt .attribution, .quoteblock .quoteblock .attribution {
-            color: inherit;
-            text-align: left;
-            margin-right: 0
-        }
-
-        table.tableblock {
-            max-width: 100%;
-            border-collapse: separate
-        }
-
-        p.tableblock:last-child {
-            margin-bottom: 0
-        }
-
-        td.tableblock > .content > :last-child {
-            margin-bottom: -1.25em
-        }
-
-        td.tableblock > .content > :last-child.sidebarblock {
-            margin-bottom: 0
-        }
-
-        table.tableblock, th.tableblock, td.tableblock {
-            border: 0 solid #dedede
-        }
-
-        table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock {
-            border-width: 0 1px 1px 0
-        }
-
-        table.grid-all > tfoot > tr > .tableblock {
-            border-width: 1px 1px 0 0
-        }
-
-        table.grid-cols > * > tr > .tableblock {
-            border-width: 0 1px 0 0
-        }
-
-        table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock {
-            border-width: 0 0 1px
-        }
-
-        table.grid-rows > tfoot > tr > .tableblock {
-            border-width: 1px 0 0
-        }
-
-        table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child {
-            border-right-width: 0
-        }
-
-        table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock {
-            border-bottom-width: 0
-        }
-
-        table.frame-all {
-            border-width: 1px
-        }
-
-        table.frame-sides {
-            border-width: 0 1px
-        }
-
-        table.frame-topbot, table.frame-ends {
-            border-width: 1px 0
-        }
-
-        table.stripes-all tr, table.stripes-odd tr:nth-of-type(odd), table.stripes-even tr:nth-of-type(even), table.stripes-hover tr:hover {
-            background: #f8f8f7
-        }
-
-        th.halign-left, td.halign-left {
-            text-align: left
-        }
-
-        th.halign-right, td.halign-right {
-            text-align: right
-        }
-
-        th.halign-center, td.halign-center {
-            text-align: center
-        }
-
-        th.valign-top, td.valign-top {
-            vertical-align: top
-        }
-
-        th.valign-bottom, td.valign-bottom {
-            vertical-align: bottom
-        }
-
-        th.valign-middle, td.valign-middle {
-            vertical-align: middle
-        }
-
-        table thead th, table tfoot th {
-            font-weight: bold
-        }
-
-        tbody tr th {
-            display: table-cell;
-            line-height: 1.6;
-            background: #f7f8f7
-        }
-
-        tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p {
-            color: rgba(0, 0, 0, .8);
-            font-weight: bold
-        }
-
-        p.tableblock > code:only-child {
-            background: none;
-            padding: 0
-        }
-
-        p.tableblock {
-            font-size: 1em
-        }
-
-        ol {
-            margin-left: 1.75em
-        }
-
-        ul li ol {
-            margin-left: 1.5em
-        }
-
-        dl dd {
-            margin-left: 1.125em
-        }
-
-        dl dd:last-child, dl dd:last-child > :last-child {
-            margin-bottom: 0
-        }
-
-        ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist {
-            margin-bottom: .625em
-        }
-
-        ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled {
-            list-style-type: none
-        }
-
-        ul.no-bullet, ol.no-bullet, ol.unnumbered {
-            margin-left: .625em
-        }
-
-        ul.unstyled, ol.unstyled {
-            margin-left: 0
-        }
-
-        ul.checklist {
-            margin-left: .625em
-        }
-
-        ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child {
-            width: 1.25em;
-            font-size: .8em;
-            position: relative;
-            bottom: .125em
-        }
-
-        ul.checklist li > p:first-child > input[type="checkbox"]:first-child {
-            margin-right: .25em
-        }
-
-        ul.inline {
-            display: -ms-flexbox;
-            display: -webkit-box;
-            display: flex;
-            -ms-flex-flow: row wrap;
-            -webkit-flex-flow: row wrap;
-            flex-flow: row wrap;
-            list-style: none;
-            margin: 0 0 .625em -1.25em
-        }
-
-        ul.inline > li {
-            margin-left: 1.25em
-        }
-
-        .unstyled dl dt {
-            font-weight: 400;
-            font-style: normal
-        }
-
-        ol.arabic {
-            list-style-type: decimal
-        }
-
-        ol.decimal {
-            list-style-type: decimal-leading-zero
-        }
-
-        ol.loweralpha {
-            list-style-type: lower-alpha
-        }
-
-        ol.upperalpha {
-            list-style-type: upper-alpha
-        }
-
-        ol.lowerroman {
-            list-style-type: lower-roman
-        }
-
-        ol.upperroman {
-            list-style-type: upper-roman
-        }
-
-        ol.lowergreek {
-            list-style-type: lower-greek
-        }
-
-        .hdlist > table, .colist > table {
-            border: 0;
-            background: none
-        }
-
-        .hdlist > table > tbody > tr, .colist > table > tbody > tr {
-            background: none
-        }
-
-        td.hdlist1, td.hdlist2 {
-            vertical-align: top;
-            padding: 0 .625em
-        }
-
-        td.hdlist1 {
-            font-weight: bold;
-            padding-bottom: 1.25em
-        }
-
-        .literalblock + .colist, .listingblock + .colist {
-            margin-top: -.5em
-        }
-
-        .colist td:not([class]):first-child {
-            padding: .4em .75em 0;
-            line-height: 1;
-            vertical-align: top
-        }
-
-        .colist td:not([class]):first-child img {
-            max-width: none
-        }
-
-        .colist td:not([class]):last-child {
-            padding: .25em 0
-        }
-
-        .thumb, .th {
-            line-height: 0;
-            display: inline-block;
-            border: solid 4px #fff;
-            -webkit-box-shadow: 0 0 0 1px #ddd;
-            box-shadow: 0 0 0 1px #ddd
-        }
-
-        .imageblock.left {
-            margin: .25em .625em 1.25em 0
-        }
-
-        .imageblock.right {
-            margin: .25em 0 1.25em .625em
-        }
-
-        .imageblock > .title {
-            margin-bottom: 0
-        }
-
-        .imageblock.thumb, .imageblock.th {
-            border-width: 6px
-        }
-
-        .imageblock.thumb > .title, .imageblock.th > .title {
-            padding: 0 .125em
-        }
-
-        .image.left, .image.right {
-            margin-top: .25em;
-            margin-bottom: .25em;
-            display: inline-block;
-            line-height: 0
-        }
-
-        .image.left {
-            margin-right: .625em
-        }
-
-        .image.right {
-            margin-left: .625em
-        }
-
-        a.image {
-            text-decoration: none;
-            display: inline-block
-        }
-
-        a.image object {
-            pointer-events: none
-        }
-
-        sup.footnote, sup.footnoteref {
-            font-size: .875em;
-            position: static;
-            vertical-align: super
-        }
-
-        sup.footnote a, sup.footnoteref a {
-            text-decoration: none
-        }
-
-        sup.footnote a:active, sup.footnoteref a:active {
-            text-decoration: underline
-        }
-
-        #footnotes {
-            padding-top: .75em;
-            padding-bottom: .75em;
-            margin-bottom: .625em
-        }
-
-        #footnotes hr {
-            width: 20%;
-            min-width: 6.25em;
-            margin: -.25em 0 .75em;
-            border-width: 1px 0 0
-        }
-
-        #footnotes .footnote {
-            padding: 0 .375em 0 .225em;
-            line-height: 1.3334;
-            font-size: .875em;
-            margin-left: 1.2em;
-            margin-bottom: .2em
-        }
-
-        #footnotes .footnote a:first-of-type {
-            font-weight: bold;
-            text-decoration: none;
-            margin-left: -1.05em
-        }
-
-        #footnotes .footnote:last-of-type {
-            margin-bottom: 0
-        }
-
-        #content #footnotes {
-            margin-top: -.625em;
-            margin-bottom: 0;
-            padding: .75em 0
-        }
-
-        .gist .file-data > table {
-            border: 0;
-            background: #fff;
-            width: 100%;
-            margin-bottom: 0
-        }
-
-        .gist .file-data > table td.line-data {
-            width: 99%
-        }
-
-        div.unbreakable {
-            page-break-inside: avoid
-        }
-
-        .big {
-            font-size: larger
-        }
-
-        .small {
-            font-size: smaller
-        }
-
-        .underline {
-            text-decoration: underline
-        }
-
-        .overline {
-            text-decoration: overline
-        }
-
-        .line-through {
-            text-decoration: line-through
-        }
-
-        .aqua {
-            color: #00bfbf
-        }
-
-        .aqua-background {
-            background: #00fafa
-        }
-
-        .black {
-            color: #000
-        }
-
-        .black-background {
-            background: #000
-        }
-
-        .blue {
-            color: #0000bf
-        }
-
-        .blue-background {
-            background: #0000fa
-        }
-
-        .fuchsia {
-            color: #bf00bf
-        }
-
-        .fuchsia-background {
-            background: #fa00fa
-        }
-
-        .gray {
-            color: #606060
-        }
-
-        .gray-background {
-            background: #7d7d7d
-        }
-
-        .green {
-            color: #006000
-        }
-
-        .green-background {
-            background: #007d00
-        }
-
-        .lime {
-            color: #00bf00
-        }
-
-        .lime-background {
-            background: #00fa00
-        }
-
-        .maroon {
-            color: #600000
-        }
-
-        .maroon-background {
-            background: #7d0000
-        }
-
-        .navy {
-            color: #000060
-        }
-
-        .navy-background {
-            background: #00007d
-        }
-
-        .olive {
-            color: #606000
-        }
-
-        .olive-background {
-            background: #7d7d00
-        }
-
-        .purple {
-            color: #600060
-        }
-
-        .purple-background {
-            background: #7d007d
-        }
-
-        .red {
-            color: #bf0000
-        }
-
-        .red-background {
-            background: #fa0000
-        }
-
-        .silver {
-            color: #909090
-        }
-
-        .silver-background {
-            background: #bcbcbc
-        }
-
-        .teal {
-            color: #006060
-        }
-
-        .teal-background {
-            background: #007d7d
-        }
-
-        .white {
-            color: #bfbfbf
-        }
-
-        .white-background {
-            background: #fafafa
-        }
-
-        .yellow {
-            color: #bfbf00
-        }
-
-        .yellow-background {
-            background: #fafa00
-        }
-
-        span.icon > .fa {
-            cursor: default
-        }
-
-        a span.icon > .fa {
-            cursor: inherit
-        }
-
-        .admonitionblock td.icon [class^="fa icon-"] {
-            font-size: 2.5em;
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, .5);
-            cursor: default
-        }
-
-        .admonitionblock td.icon .icon-note::before {
-            content: "\f05a";
-            color: #19407c
-        }
-
-        .admonitionblock td.icon .icon-tip::before {
-            content: "\f0eb";
-            text-shadow: 1px 1px 2px rgba(155, 155, 0, .8);
-            color: #111
-        }
-
-        .admonitionblock td.icon .icon-warning::before {
-            content: "\f071";
-            color: #bf6900
-        }
-
-        .admonitionblock td.icon .icon-caution::before {
-            content: "\f06d";
-            color: #bf3400
-        }
-
-        .admonitionblock td.icon .icon-important::before {
-            content: "\f06a";
-            color: #bf0000
-        }
-
-        .conum[data-value] {
-            display: inline-block;
-            color: #fff !important;
-            background: rgba(0, 0, 0, .8);
-            -webkit-border-radius: 100px;
-            border-radius: 100px;
-            text-align: center;
-            font-size: .75em;
-            width: 1.67em;
-            height: 1.67em;
-            line-height: 1.67em;
-            font-family: "Open Sans", "DejaVu Sans", sans-serif;
-            font-style: normal;
-            font-weight: bold
-        }
-
-        .conum[data-value] * {
-            color: #fff !important
-        }
-
-        .conum[data-value] + b {
-            display: none
-        }
-
-        .conum[data-value]::after {
-            content: attr(data-value)
-        }
-
-        pre .conum[data-value] {
-            position: relative;
-            top: -.125em
-        }
-
-        b.conum * {
-            color: inherit !important
-        }
-
-        .conum:not([data-value]):empty {
-            display: none
-        }
-
-        dt, th.tableblock, td.content, div.footnote {
-            text-rendering: optimizeLegibility
-        }
-
-        h1, h2, p, td.content, span.alt {
-            letter-spacing: -.01em
-        }
-
-        p strong, td.content strong, div.footnote strong {
-            letter-spacing: -.005em
-        }
-
-        p, blockquote, dt, td.content, span.alt {
-            font-size: 1.0625rem
-        }
-
-        p {
-            margin-bottom: 1.25rem
-        }
-
-        .sidebarblock p, .sidebarblock dt, .sidebarblock td.content, p.tableblock {
-            font-size: 1em
-        }
-
-        .exampleblock > .content {
-            background: #fffef7;
-            border-color: #e0e0dc;
-            -webkit-box-shadow: 0 1px 4px #e0e0dc;
-            box-shadow: 0 1px 4px #e0e0dc
-        }
-
-        .print-only {
-            display: none !important
-        }
-
-        @page {
-            margin: 1.25cm .75cm
-        }
-
-        @media print {
-            * {
-                -webkit-box-shadow: none !important;
-                box-shadow: none !important;
-                text-shadow: none !important
-            }
-
-            html {
-                font-size: 80%
-            }
-
-            a {
-                color: inherit !important;
-                text-decoration: underline !important
-            }
-
-            a.bare, a[href^="#"], a[href^="mailto:"] {
-                text-decoration: none !important
-            }
-
-            a[href^="http:"]:not(.bare)::after, a[href^="https:"]:not(.bare)::after {
-                content: "(" attr(href) ")";
-                display: inline-block;
-                font-size: .875em;
-                padding-left: .25em
-            }
-
-            abbr[title]::after {
-                content: " (" attr(title) ")"
-            }
-
-            pre, blockquote, tr, img, object, svg {
-                page-break-inside: avoid
-            }
-
-            thead {
-                display: table-header-group
-            }
-
-            svg {
-                max-width: 100%
-            }
-
-            p, blockquote, dt, td.content {
-                font-size: 1em;
-                orphans: 3;
-                widows: 3
-            }
-
-            h2, h3, #toctitle, .sidebarblock > .content > .title {
-                page-break-after: avoid
-            }
-
-            #toc, .sidebarblock, .exampleblock > .content {
-                background: none !important
-            }
-
-            #toc {
-                border-bottom: 1px solid #dddddf !important;
-                padding-bottom: 0 !important
-            }
-
-            body.book #header {
-                text-align: center
-            }
-
-            body.book #header > h1:first-child {
-                border: 0 !important;
-                margin: 2.5em 0 1em
-            }
-
-            body.book #header .details {
-                border: 0 !important;
-                display: block;
-                padding: 0 !important
-            }
-
-            body.book #header .details span:first-child {
-                margin-left: 0 !important
-            }
-
-            body.book #header .details br {
-                display: block
-            }
-
-            body.book #header .details br + span::before {
-                content: none !important
-            }
-
-            body.book #toc {
-                border: 0 !important;
-                text-align: left !important;
-                padding: 0 !important;
-                margin: 0 !important
-            }
-
-            body.book #toc, body.book #preamble, body.book h1.sect0, body.book .sect1 > h2 {
-                page-break-before: always
-            }
-
-            .listingblock code[data-lang]::before {
-                display: block
-            }
-
-            #footer {
-                padding: 0 .9375em
-            }
-
-            .hide-on-print {
-                display: none !important
-            }
-
-            .print-only {
-                display: block !important
-            }
-
-            .hide-for-print {
-                display: none !important
-            }
-
-            .show-for-print {
-                display: inherit !important
-            }
-        }
-
-        @media print, amzn-kf8 {
-            #header > h1:first-child {
-                margin-top: 1.25rem
-            }
-
-            .sect1 {
-                padding: 0 !important
-            }
-
-            .sect1 + .sect1 {
-                border: 0
-            }
-
-            #footer {
-                background: none
-            }
-
-            #footer-text {
-                color: rgba(0, 0, 0, .6);
-                font-size: .9em
-            }
-        }
-
-        @media amzn-kf8 {
-            #header, #content, #footnotes, #footer {
-                padding: 0
-            }
-        }
-    </style>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="author" content="Wilder&lt;gyuhanKang@gmail.com&gt;">
+<title>Babble API Docs</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-    <h1>Babble API Docs</h1>
-    <div class="details">
-        <span class="author" id="author">Wilder&lt;gyuhanKang@gmail.com&gt;</span><br>
-        <span id="revnumber">version 0.0.1-SNAPSHOT,</span>
-        <span id="revdate">15/07/2021</span>
-    </div>
-    <div class="toc2" id="toc">
-        <div id="toctitle">Table of Contents</div>
-        <ul class="sectlevel1">
-            <li><a href="#_방_생성_api">1. 방 생성 API</a>
-                <ul class="sectlevel2">
-                    <li><a href="#_http_request">1.1. HTTP Request</a></li>
-                    <li><a href="#_http_response">1.2. HTTP Response</a></li>
-                </ul>
-            </li>
-            <li><a href="#_방_조회_api">2. 방 조회 API</a>
-                <ul class="sectlevel2">
-                    <li><a href="#_http_request_2">2.1. HTTP Request</a></li>
-                    <li><a href="#_http_response_2">2.2. HTTP Response</a></li>
-                </ul>
-            </li>
-        </ul>
-    </div>
+<h1>Babble API Docs</h1>
+<div class="details">
+<span id="author" class="author">Wilder&lt;gyuhanKang@gmail.com&gt;</span><br>
+<span id="revnumber">version 0.0.1-SNAPSHOT,</span>
+<span id="revdate">15/07/2021</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_방_생성_api">1. 방 생성 API</a>
+<ul class="sectlevel2">
+<li><a href="#_http_request">1.1. HTTP Request</a></li>
+<li><a href="#_http_response">1.2. HTTP Response</a></li>
+</ul>
+</li>
+<li><a href="#_방_조회_api">2. 방 조회 API</a>
+<ul class="sectlevel2">
+<li><a href="#_http_request_2">2.1. HTTP Request</a></li>
+<li><a href="#_http_response_2">2.2. HTTP Response</a></li>
+</ul>
+</li>
+</ul>
+</div>
 </div>
 <div id="content">
-    <div id="preamble">
-        <div class="sectionbody">
-            <table class="tableblock frame-all grid-all" style="width: 15%;">
-                <colgroup>
-                    <col style="width: 50%;">
-                    <col style="width: 50%;">
-                </colgroup>
-                <thead>
-                <tr>
-                    <th class="tableblock halign-center valign-top">Method</th>
-                    <th class="tableblock halign-center valign-top">Content</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock"><code>GET</code></p></td>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock">읽기</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock"><code>POST</code></p></td>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock">추가</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock"><code>PUT</code></p></td>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock">수정</p></td>
-                </tr>
-                <tr>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock"><code>DELETE</code></p></td>
-                    <td class="tableblock halign-center valign-top"><p class="tableblock">삭제</p></td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-    <div class="sect1">
-        <h2 id="_방_생성_api">1. 방 생성 API</h2>
-        <div class="sectionbody">
-            <div class="sect2">
-                <h3 id="_http_request">1.1. HTTP Request</h3>
-                <div class="listingblock">
-                    <div class="content">
+<div id="preamble">
+<div class="sectionbody">
+<table class="tableblock frame-all grid-all" style="width: 15%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Method</th>
+<th class="tableblock halign-center valign-top">Content</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>GET</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">읽기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>POST</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">추가</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>PUT</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">수정</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>DELETE</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">삭제</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_방_생성_api">1. 방 생성 API</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_http_request">1.1. HTTP Request</h3>
+<div class="listingblock">
+<div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/rooms HTTP/1.1
 Content-Type: application/json
 Accept: application/json
-Content-Length: 86
+Content-Length: 127
 Host: localhost:8080
 
 {
   "gameId" : 1,
-  "hostId" : 1,
-  "tags" : [ "실버", "2시간", "솔로랭크" ]
+  "tags" : [ {
+    "name" : "실버"
+  }, {
+    "name" : "2시간"
+  }, {
+    "name" : "솔로랭크"
+  } ]
 }</code></pre>
-                    </div>
-                </div>
-                <table class="tableblock frame-all grid-all" style="width: 40%;">
-                    <colgroup>
-                        <col style="width: 33.3333%;">
-                        <col style="width: 33.3333%;">
-                        <col style="width: 33.3334%;">
-                    </colgroup>
-                    <thead>
-                    <tr>
-                        <th class="tableblock halign-center valign-top">Path</th>
-                        <th class="tableblock halign-center valign-top">Type</th>
-                        <th class="tableblock halign-center valign-top">Description</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>gameId</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">게임 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>hostId</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">호스트 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>tags</code></p></td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Array</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">태그 리스트</p></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="sect2">
-                <h3 id="_http_response">1.2. HTTP Response</h3>
-                <div class="listingblock">
-                    <div class="content">
+</div>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Path</th>
+<th class="tableblock halign-center valign-top">Type</th>
+<th class="tableblock halign-center valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>gameId</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>tags[].name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">태그 리스트</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_http_response">1.2. HTTP Response</h3>
+<div class="listingblock">
+<div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
-Location: api/rooms/5
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: api/rooms/6
 Content-Type: application/json
 Content-Length: 236
 
 {
-  "roomId" : 5,
-  "createdDate" : "2021-07-16T04:50:28.233557",
+  "roomId" : 6,
+  "createdDate" : "2021-07-25T02:02:15.834",
   "game" : {
     "id" : 1,
     "name" : "League Of Legend"
   },
-  "host" : {
-    "id" : 1,
-    "name" : "루트"
-  },
-  "tags" : [ "실버", "2시간", "솔로랭크" ]
+  "tags" : [ {
+    "name" : "실버"
+  }, {
+    "name" : "2시간"
+  }, {
+    "name" : "솔로랭크"
+  } ]
 }</code></pre>
-                    </div>
-                </div>
-                <table class="tableblock frame-all grid-all" style="width: 40%;">
-                    <colgroup>
-                        <col style="width: 33.3333%;">
-                        <col style="width: 33.3333%;">
-                        <col style="width: 33.3334%;">
-                    </colgroup>
-                    <thead>
-                    <tr>
-                        <th class="tableblock halign-center valign-top">Path</th>
-                        <th class="tableblock halign-center valign-top">Type</th>
-                        <th class="tableblock halign-center valign-top">Description</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>roomId</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">방 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>createdDate</code>
-                        </p></td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">방 생성 시각</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.id</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">게임 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.name</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">게임 이름</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>host.id</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">호스트 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>host.name</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">호스트 닉네임</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>tags</code></p></td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Array</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">태그 리스트</p></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-    <div class="sect1">
-        <h2 id="_방_조회_api">2. 방 조회 API</h2>
-        <div class="sectionbody">
-            <div class="sect2">
-                <h3 id="_http_request_2">2.1. HTTP Request</h3>
-                <div class="listingblock">
-                    <div class="content">
+</div>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Path</th>
+<th class="tableblock halign-center valign-top">Type</th>
+<th class="tableblock halign-center valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>roomId</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">방 Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>createdDate</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">방 생성 시각</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.id</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>tags[].name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">태그 리스트</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_방_조회_api">2. 방 조회 API</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_http_request_2">2.1. HTTP Request</h3>
+<div class="listingblock">
+<div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/rooms/1 HTTP/1.1
 Accept: application/json
 Host: localhost:8080</code></pre>
-                    </div>
-                </div>
-            </div>
-            <div class="sect2">
-                <h3 id="_http_response_2">2.2. HTTP Response</h3>
-                <div class="listingblock">
-                    <div class="content">
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_http_response_2">2.2. HTTP Response</h3>
+<div class="listingblock">
+<div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 220
+Content-Length: 201
 
 {
   "roomId" : 1,
-  "createdDate" : "2021-07-16T04:50:26.032303",
+  "createdDate" : "2021-07-25T02:02:14.836",
   "game" : {
     "id" : 1,
     "name" : "League Of Legend"
   },
-  "host" : {
-    "id" : 1,
-    "name" : "루트"
-  },
-  "tags" : [ "실버", "2시간" ]
+  "tags" : [ {
+    "name" : "실버"
+  }, {
+    "name" : "2시간"
+  } ]
 }</code></pre>
-                    </div>
-                </div>
-                <table class="tableblock frame-all grid-all" style="width: 40%;">
-                    <colgroup>
-                        <col style="width: 33.3333%;">
-                        <col style="width: 33.3333%;">
-                        <col style="width: 33.3334%;">
-                    </colgroup>
-                    <thead>
-                    <tr>
-                        <th class="tableblock halign-center valign-top">Path</th>
-                        <th class="tableblock halign-center valign-top">Type</th>
-                        <th class="tableblock halign-center valign-top">Description</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>roomId</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">방 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>createdDate</code>
-                        </p></td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">방 생성 시각</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.id</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">게임 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.name</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">게임 이름</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>host.id</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">호스트 Id</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>host.name</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">호스트 닉네임</p></td>
-                    </tr>
-                    <tr>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>tags</code></p></td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock"><code>Array</code></p>
-                        </td>
-                        <td class="tableblock halign-center valign-top"><p class="tableblock">태그 리스트</p></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
+</div>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Path</th>
+<th class="tableblock halign-center valign-top">Type</th>
+<th class="tableblock halign-center valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>roomId</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">방 Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>createdDate</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">방 생성 시각</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.id</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 Id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>game.name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>tags[].name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">태그 리스트</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
-    <div id="footer-text">
-        Version 0.0.1-SNAPSHOT<br>
-        Last updated 2021-07-16 04:49:57 +0900
-    </div>
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2021-07-16 10:41:46 +0900
+</div>
 </div>
 </body>
 </html>

--- a/back/babble/src/test/java/gg/babble/babble/controller/TagControllerTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/controller/TagControllerTest.java
@@ -1,0 +1,54 @@
+package gg.babble.babble.controller;
+
+import gg.babble.babble.AcceptanceTest;
+import gg.babble.babble.dto.TagResponse;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TagControllerTest extends AcceptanceTest {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+    @DisplayName("전체 태그를 가져오는데 성공하면, 200응답 코드와 전체 태그를 가져온다.")
+    @Test
+    void webSocketConnectTest() {
+        //given
+        List<TagResponse> expectedTagResponses = Arrays.asList(
+                TagResponse.builder()
+                        .name("2시간")
+                        .build(),
+                TagResponse.builder()
+                        .name("솔로랭크")
+                        .build(),
+                TagResponse.builder()
+                        .name("실버")
+                        .build()
+        );
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .get("/api/tags")
+                .then().log().all()
+                .extract();
+
+        List<TagResponse> tagResponses = response.jsonPath().getList(".", TagResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(tagResponses).usingRecursiveComparison().isEqualTo(expectedTagResponses);
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/ApiDocumentationIntegrationTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/ApiDocumentationIntegrationTest.java
@@ -2,6 +2,7 @@ package gg.babble.babble.restdocs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.dto.TagRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,11 +19,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -50,7 +51,7 @@ public class ApiDocumentationIntegrationTest extends ApplicationTest {
     public void createRoomTest() throws Exception {
         Map<String, Object> body = new HashMap<>();
         body.put("gameId", 1L);
-        body.put("tags", Arrays.asList("실버", "2시간", "솔로랭크"));
+        body.put("tags", Arrays.asList(new TagRequest("실버"), new TagRequest("2시간"), new TagRequest("솔로랭크")));
         mockMvc.perform(post("/api/rooms")
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -62,37 +63,39 @@ public class ApiDocumentationIntegrationTest extends ApplicationTest {
                 .andExpect(jsonPath("$.game.name").exists())
                 .andExpect(jsonPath("$.tags").isArray())
                 .andExpect(jsonPath("$.tags", hasSize(3)))
-                .andExpect(jsonPath("$.tags", hasItem("실버")))
-                .andExpect(jsonPath("$.tags", hasItem("솔로랭크")))
-                .andExpect(jsonPath("$.tags", hasItem("2시간")))
+                .andExpect(jsonPath("$.tags[0].name").value("실버"))
+                .andExpect(jsonPath("$.tags[1].name").value("2시간"))
+                .andExpect(jsonPath("$.tags[2].name").value("솔로랭크"))
+
                 .andDo(document("create-room",
                         requestFields(fieldWithPath("gameId").description("게임 Id"),
-                                fieldWithPath("tags").description("태그 리스트")),
+                                fieldWithPath("tags[].name").description("태그 리스트")),
                         responseFields(fieldWithPath("roomId").description("방 Id"),
                                 fieldWithPath("createdDate").description("방 생성 시각"),
                                 fieldWithPath("game.id").description("게임 Id"),
                                 fieldWithPath("game.name").description("게임 이름"),
-                                fieldWithPath("tags").description("태그 리스트"))));
+                                fieldWithPath("tags[].name").description("태그 리스트"))));
     }
 
-//    @Test
-//    public void readRoomTest() throws Exception {
-//        mockMvc.perform(get("/api/rooms/1")
-//                .accept(MediaType.APPLICATION_JSON_VALUE))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.roomId").exists())
-//                .andExpect(jsonPath("$.createdDate").exists())
-//                .andExpect(jsonPath("$.game.id").value(1))
-//                .andExpect(jsonPath("$.game.name").exists())
-//                .andExpect(jsonPath("$.tags").isArray())
-//                .andExpect(jsonPath("$.tags", hasSize(2)))
-//                .andExpect(jsonPath("$.tags", hasItem("실버")))
-//                .andExpect(jsonPath("$.tags", hasItem("2시간")))
-//                .andDo(document("read-room",
-//                        responseFields(fieldWithPath("roomId").description("방 Id"),
-//                                fieldWithPath("createdDate").description("방 생성 시각"),
-//                                fieldWithPath("game.id").description("게임 Id"),
-//                                fieldWithPath("game.name").description("게임 이름"),
-//                                fieldWithPath("tags").description("태그 리스트"))));
-//    }
+    @Test
+    public void readRoomTest() throws Exception {
+        mockMvc.perform(get("/api/rooms/1")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").exists())
+                .andExpect(jsonPath("$.createdDate").exists())
+                .andExpect(jsonPath("$.game.id").value(1))
+                .andExpect(jsonPath("$.game.name").exists())
+                .andExpect(jsonPath("$.tags").isArray())
+                .andExpect(jsonPath("$.tags", hasSize(2)))
+                .andExpect(jsonPath("$.tags[0].name").value("실버"))
+                .andExpect(jsonPath("$.tags[1].name").value("2시간"))
+
+                .andDo(document("read-room",
+                        responseFields(fieldWithPath("roomId").description("방 Id"),
+                                fieldWithPath("createdDate").description("방 생성 시각"),
+                                fieldWithPath("game.id").description("게임 Id"),
+                                fieldWithPath("game.name").description("게임 이름"),
+                                fieldWithPath("tags[].name").description("태그 리스트"))));
+    }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
@@ -1,22 +1,70 @@
 package gg.babble.babble.service;
 
 import gg.babble.babble.ApplicationTest;
-import gg.babble.babble.exception.BabbleNotFoundException;
+import gg.babble.babble.dto.TagResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TagServiceTest extends ApplicationTest {
 
     @Autowired
     private TagService tagService;
 
-    @DisplayName("존재하지 않는 태그면 예외 처리한다.")
+//    // data Loader class 호출을 없애길 희망.
+//    // TODO : 프로필에 테스트 data Loader에서만 처리하게 하거나, 모여서 할 이야기라서 일단 keep
+//    @Autowired
+//    private TagRepository tagRepository;
+//
+//    @BeforeEach
+//    private void prepareDummyTags() {
+//        tagRepository.save(Tag.builder()
+//                .name("2시간")
+//                .build()
+//        );
+//        tagRepository.save(Tag.builder()
+//                .name("솔로랭크")
+//                .build()
+//        );
+//        tagRepository.save(Tag.builder()
+//                .name("실버")
+//                .build()
+//        );
+//    }
+//
+//    @DisplayName("존재하지 않는 태그면 예외 처리한다.")
+//    @Test
+//    void tagNotFoundTest() {
+//        assertThatThrownBy(() -> tagService.findById("쏙옙뷁훑"))
+//                .isInstanceOf(BabbleNotFoundException.class);
+//    }
+
+    @DisplayName("태그 전체를 불러오면, DB에 존재하는 모든 태그를 불러온다.")
     @Test
-    void tagNotFoundTest() {
-        assertThatThrownBy(() -> tagService.findById("쏙옙뷁훑"))
-                .isInstanceOf(BabbleNotFoundException.class);
+    void getAllTags() {
+
+        // given
+        List<TagResponse> expectedTags = Arrays.asList(
+                TagResponse.builder()
+                        .name("2시간")
+                        .build(),
+                TagResponse.builder()
+                        .name("솔로랭크")
+                        .build(),
+                TagResponse.builder()
+                        .name("실버")
+                        .build()
+        );
+
+        // when
+        List<TagResponse> allTags = tagService.getAllTags();
+
+        // then
+        assertThat(expectedTags).usingRecursiveComparison().isEqualTo(allTags);
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
@@ -2,6 +2,7 @@ package gg.babble.babble.service;
 
 import gg.babble.babble.ApplicationTest;
 import gg.babble.babble.dto.TagResponse;
+import gg.babble.babble.exception.BabbleNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TagServiceTest extends ApplicationTest {
 
@@ -37,12 +39,12 @@ public class TagServiceTest extends ApplicationTest {
 //        );
 //    }
 //
-//    @DisplayName("존재하지 않는 태그면 예외 처리한다.")
-//    @Test
-//    void tagNotFoundTest() {
-//        assertThatThrownBy(() -> tagService.findById("쏙옙뷁훑"))
-//                .isInstanceOf(BabbleNotFoundException.class);
-//    }
+    @DisplayName("존재하지 않는 태그면 예외 처리한다.")
+    @Test
+    void tagNotFoundTest() {
+        assertThatThrownBy(() -> tagService.findById("쏙옙뷁훑"))
+                .isInstanceOf(BabbleNotFoundException.class);
+    }
 
     @DisplayName("태그 전체를 불러오면, DB에 존재하는 모든 태그를 불러온다.")
     @Test


### PR DESCRIPTION
- 전체 태그를 불러오는 기능 구현
- 수정된 API 명세에 맞춰, 요청 응답에 String 필드로 관리하던 tag를 포장 하도록 수정

## 문제 발생 `해결`

- `ApiDocumentationIntegrationTest.class` 에서 문제 발생

![image](https://user-images.githubusercontent.com/43930419/126874435-fa341603-8ce2-4b49-a1a5-1763d788a771.png)

![image](https://user-images.githubusercontent.com/43930419/126874502-13a8ac9a-b3a6-4550-801a-3d28ef341e1a.png)


기존에는 String으로 관리해서 hasItem으로 처리가 되었던것 같으나, 포장한뒤 문제가 되는중.  
hasItem 내부에 리스트형태로 넣어주어도 문제가 발생

![image](https://user-images.githubusercontent.com/43930419/126874534-33529d75-dacf-43bd-8d99-0f7eb84db04c.png)
내부값을 뽑아와서 비교를 해보아도 문제가 발생  

이부분에 대한 해결책을 RestDocs 관련 지식이 미흡한 상태로는 찾지못함


---


# 논의거리

![image](https://user-images.githubusercontent.com/43930419/126874557-6d458667-8b4e-4a94-90e8-f66c63e05613.png)

**요청**의 경우에도 tag 포장이 필요한지에 대한 의문이 생김.

응답에 관해서는 나중에 다른 정보를 더 담을 가능성이 있어, 포장하는게 맞지만   
**요청**에서는 key값으로만 쓰이는 이름만 보내줘도 문제가 없을것으로 사료됨.

