### PR TITLE
fix: 검색창 컴포넌트 자동완성 기능에 debounce 적용

### DIFF
--- a/front/src/components/SearchInput/SearchInput.js
+++ b/front/src/components/SearchInput/SearchInput.js
@@ -12,6 +12,7 @@ const SearchInput = ({
   placeholder = '태그를 검색해주세요.',
   autoCompleteKeywords,
 }) => {
+  const { debounce } = useDebounce(500);
   const [autoCompleteList, setAutoCompleteList] = useState([]);
   const containerRef = useRef(null);
   const autoCompleteRef = useRef(null);
@@ -57,6 +58,10 @@ const SearchInput = ({
     setAutoCompleteList(searchResults);
   };
 
+  const onChangeInputDebounced = (e) => {
+    debounce(() => onChangeInput(e));
+  };
+
   useEffect(() => {
     setAutoCompleteList(autoCompleteKeywords);
   }, []);
@@ -70,7 +75,7 @@ const SearchInput = ({
         placeholder={placeholder}
         onFocus={onFocusInput}
         onBlur={onBlurInput}
-        onChange={onChangeInput}
+        onChange={onChangeInputDebounced}
       />
       <ul className='keyword-list-container' ref={autoCompleteRef}>
         {autoCompleteList.length ? (

--- a/front/src/hooks/useDebounce.js
+++ b/front/src/hooks/useDebounce.js
@@ -1,0 +1,17 @@
+import React, { useRef } from 'react';
+
+const useDebounce = (delay) => {
+  const timerRef = useRef(null);
+
+  const debounce = (callback) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    timerRef.current = setTimeout(() => {
+      callback();
+    }, delay);
+  };
+
+  return { debounce };
+};
+
+export default useDebounce;


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
![debounce](https://user-images.githubusercontent.com/42052110/127112100-4daeccf3-2b7f-40a5-a730-c3431b86e02d.gif)

## 🔥 구현 내용 요약
- 검색창 컴포넌트의 onChange에 자동완성 기능을 달아놨는데, onChange가 발생할 때마다 자동완성이 일어나면 계산도 너무 자주 일어나고, 리렌더링도 너무 자주 일어나서 매우 비효율적인 동작이 수행되게 됩니다. 
- 그래서 debounce를 통해 자동완성 기능의 수행 시점을 늦춰서 조금 더 효율적으로 동작하게끔 만들어줬습니당

## ☠ 트러블 슈팅
- useDebounce를 콜백 함수를 받는 custom hook으로 만들어놨는데, 인자로 들어가는 callback function은 주로 이벤트 리스너 함수이다보니, 호이스팅 문제로 인해 hook을 맨 위에 선언해놓지 못하는 문제가 있었습니다.
- 그래서 useDebounce hook 자체로 콜백 함수를 받는 것이 아니라, useDebounce가 return하는 'debounce' 라는 함수가 직접 콜백 함수를 받아서 실행하도록 변경해주었습니다.
- 그렇게 하니깐, 또 인자로 '함수'를 넣어줘야 하기 때문에 `() => {}` 꼴로 이벤트 리스너 함수를 한 번 더 감싸줘야하는 번거로움이 있었습니다. inline function으로 집어넣으니 코드가 너무나도 못생겨서, debounce를 씌운 별도의 함수를 하나 더 선언해줬습니다.
```javascript
const onChangeInputDebounced = (e) => {
  debounce(() => onChangeInput(e));
};
```
- 추후에 useDebounce 훅을 `여러 개의 timer 키를 객체 혹은 배열로 관리하는 일반 함수`로 만들면 어떨까 생각중. 그렇게 하면 여러 개의 타이머를 관리할 수 있다. (지금은 각자의 컴포넌트가 timer를 가지고 있게 하기 위해 ref를 사용함. )