### PR TITLE
게임 이미지 요청 API 기능 구현

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/DataLoader.java
+++ b/back/babble/src/main/java/gg/babble/babble/DataLoader.java
@@ -59,7 +59,7 @@ public class DataLoader implements CommandLineRunner {
 
 
     private void prepareDummyGames() {
-        gameRepository.save(new Game(LEAGUE_OF_LEGENDS));
+        gameRepository.save(new Game(LEAGUE_OF_LEGENDS, "https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg"));
         gameRepository.save(new Game(OVERWATCH));
         gameRepository.save(new Game(APEX_LEGEND));
     }

--- a/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
@@ -2,6 +2,7 @@ package gg.babble.babble.controller;
 
 import gg.babble.babble.dto.GameImageResponse;
 import gg.babble.babble.service.GameService;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,5 +22,10 @@ public class GameController {
     @GetMapping(value = "/{gameId}/images")
     public ResponseEntity<GameImageResponse> findGameImage(@PathVariable final Long gameId) {
         return ResponseEntity.ok(gameService.findGameImageById(gameId));
+    }
+
+    @GetMapping(value = "/images")
+    public ResponseEntity<List<GameImageResponse>> findAllGameImages() {
+        return ResponseEntity.ok(gameService.findAllGameImages());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
@@ -1,0 +1,25 @@
+package gg.babble.babble.controller;
+
+import gg.babble.babble.dto.GameImageResponse;
+import gg.babble.babble.service.GameService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/api/games")
+@RestController
+public class GameController {
+
+    private final GameService gameService;
+
+    public GameController(final GameService gameService) {
+        this.gameService = gameService;
+    }
+
+    @GetMapping(value = "/{gameId}/images")
+    public ResponseEntity<GameImageResponse> findGameImage(@PathVariable final Long gameId) {
+        return ResponseEntity.ok(gameService.findGameImageById(gameId));
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/Game.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/Game.java
@@ -17,6 +17,7 @@ import org.springframework.lang.NonNull;
 @Entity
 public class Game {
 
+    private static final String DEFAULT_IMAGE = "https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg";
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,8 +25,19 @@ public class Game {
     @NonNull
     private String name;
 
+    @NonNull
+    private String image;
+
     public Game(@NonNull final String name) {
-        this(null, name);
+        this(null, name, DEFAULT_IMAGE);
+    }
+
+    public Game(final Long id, @NonNull final String name) {
+        this(id, name, DEFAULT_IMAGE);
+    }
+
+    public Game(@NonNull final String name, @NonNull final String image) {
+        this(null, name, image);
     }
 
     @Override

--- a/back/babble/src/main/java/gg/babble/babble/domain/room/MaxHeadCount.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/room/MaxHeadCount.java
@@ -5,7 +5,6 @@ import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.logging.log4j.util.Strings;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/back/babble/src/main/java/gg/babble/babble/dto/GameImageResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/GameImageResponse.java
@@ -1,0 +1,12 @@
+package gg.babble.babble.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GameImageResponse {
+
+    private final Long gameId;
+    private final String image;
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/GameImageResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/GameImageResponse.java
@@ -1,5 +1,6 @@
 package gg.babble.babble.dto;
 
+import gg.babble.babble.domain.Game;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,4 +10,8 @@ public class GameImageResponse {
 
     private final Long gameId;
     private final String image;
+
+    public static GameImageResponse from(final Game game) {
+        return new GameImageResponse(game.getId(), game.getImage());
+    }
 }

--- a/back/babble/src/main/java/gg/babble/babble/service/GameService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/GameService.java
@@ -5,6 +5,7 @@ import gg.babble.babble.domain.repository.GameRepository;
 import gg.babble.babble.dto.GameImageResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +29,13 @@ public class GameService {
     }
 
     public GameImageResponse findGameImageById(final Long gameId) {
-        Game game = findById(gameId);
-        return new GameImageResponse(game.getId(), game.getImage());
+        return GameImageResponse.from(findById(gameId));
+    }
+
+    public List<GameImageResponse> findAllGameImages() {
+        return gameRepository.findAll()
+            .stream()
+            .map(GameImageResponse::from)
+            .collect(Collectors.toList());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/service/GameService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/GameService.java
@@ -2,6 +2,7 @@ package gg.babble.babble.service;
 
 import gg.babble.babble.domain.Game;
 import gg.babble.babble.domain.repository.GameRepository;
+import gg.babble.babble.dto.GameImageResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -24,5 +25,10 @@ public class GameService {
 
     public List<Game> findByName(final String name) {
         return gameRepository.findByName(name);
+    }
+
+    public GameImageResponse findGameImageById(final Long gameId) {
+        Game game = findById(gameId);
+        return new GameImageResponse(game.getId(), game.getImage());
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/domain/MaxHeadCountTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/MaxHeadCountTest.java
@@ -1,12 +1,10 @@
 package gg.babble.babble.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import gg.babble.babble.domain.room.MaxHeadCount;
 import gg.babble.babble.exception.BabbleIllegalArgumentException;
-import gg.babble.babble.exception.BabbleNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/back/babble/src/test/java/gg/babble/babble/domain/repository/RoomRepositoryTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/repository/RoomRepositoryTest.java
@@ -42,7 +42,7 @@ public class RoomRepositoryTest extends ApplicationTest {
     void dummyGameTest() {
         Room room = roomRepository.findAll().get(0);
 
-        Game expectedGame = new Game(LEAGUE_OF_LEGENDS);
+        Game expectedGame = new Game(LEAGUE_OF_LEGENDS, "https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg");
         User expectedHost = new User(루트, room);
 
         List<String> expectedTags = Arrays.asList(실버, _2시간);

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
@@ -1,0 +1,57 @@
+package gg.babble.babble.restdocs;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gg.babble.babble.ApplicationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+public class GameApiDocumentTest extends ApplicationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(documentationConfiguration(restDocumentation))
+            .alwaysDo(document("{method-name}", preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint())))
+            .build();
+    }
+
+    @DisplayName("단일 게임 이미지 조회")
+    @Test
+    void findGameImageById() throws Exception {
+        mockMvc.perform(get("/api/games/1/images")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.gameId").value(1L))
+            .andExpect(jsonPath("$.image").value("https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg"))
+
+            .andDo(document("read-game-image",
+                responseFields(fieldWithPath("gameId").description("게임 Id"),
+                    fieldWithPath("image").description("이미지 URL"))
+                )
+            );
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
@@ -1,6 +1,5 @@
 package gg.babble.babble.restdocs;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -51,6 +50,26 @@ public class GameApiDocumentTest extends ApplicationTest {
             .andDo(document("read-game-image",
                 responseFields(fieldWithPath("gameId").description("게임 Id"),
                     fieldWithPath("image").description("이미지 URL"))
+                )
+            );
+    }
+
+    @DisplayName("전체 게임 이미지 목록 조회")
+    @Test
+    void findGameImages() throws Exception {
+        mockMvc.perform(get("/api/games/images")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].gameId").value(1L))
+            .andExpect(jsonPath("$[0].image").value("https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg"))
+            .andExpect(jsonPath("$[1].gameId").value(2L))
+            .andExpect(jsonPath("$[1].image").value("https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg"))
+            .andExpect(jsonPath("$[2].gameId").value(3L))
+            .andExpect(jsonPath("$[2].image").value("https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg"))
+
+            .andDo(document("read-game-image",
+                responseFields(fieldWithPath("[].gameId").description("게임 Id"),
+                    fieldWithPath("[].image").description("이미지 URL"))
                 )
             );
     }

--- a/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
@@ -1,8 +1,10 @@
 package gg.babble.babble.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.dto.GameImageResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class GameServiceTest extends ApplicationTest {
 
+    private static final String LEAGUE_OF_LEGENDS_URL = "https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg";
     @Autowired
     private GameService gameService;
 
@@ -18,5 +21,16 @@ class GameServiceTest extends ApplicationTest {
     void gameNotFoundTest() {
         assertThatThrownBy(() -> gameService.findById(Long.MAX_VALUE))
             .isInstanceOf(BabbleNotFoundException.class);
+    }
+
+    @DisplayName("게임에 해당하는 이미지를 반환한다.")
+    @Test
+    void findGameImageById() {
+        // given
+        GameImageResponse expectedResponse = new GameImageResponse(1L, LEAGUE_OF_LEGENDS_URL);
+
+        // then
+        assertThat(gameService.findGameImageById(1L)).usingRecursiveComparison()
+            .isEqualTo(expectedResponse);
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import gg.babble.babble.ApplicationTest;
 import gg.babble.babble.dto.GameImageResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,5 +34,20 @@ class GameServiceTest extends ApplicationTest {
         // then
         assertThat(gameService.findGameImageById(1L)).usingRecursiveComparison()
             .isEqualTo(expectedResponse);
+    }
+
+    @DisplayName("전체 게임 이미지 목록을 반환한다.")
+    @Test
+    void gameImages() {
+        // given
+        List<GameImageResponse> expectedResponses = Arrays.asList(
+            new GameImageResponse(1L, LEAGUE_OF_LEGENDS_URL),
+            new GameImageResponse(2L, "https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg"),
+            new GameImageResponse(3L, "https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg")
+        );
+
+        // then
+        assertThat(gameService.findAllGameImages()).usingRecursiveComparison()
+            .isEqualTo(expectedResponses);
     }
 }


### PR DESCRIPTION
## 🔥 구현 내용 요약
단일 게임 이미지 요청, 전체 게임 이미지 목록 요청 구현

## ☠ 트러블 슈팅
게임 이미지가 등록되지 않은 경우, default 이미지를 사용하도록 매핑했습니다.
추후 게임의 이미지 필드`Game.image(string)`을 원시값 포장 리팩토링을 진행하면서 보완할 계획입니다.