### PR TITLE
초기 페이지 게임 리스트 조회 API 구현

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
@@ -1,6 +1,7 @@
 package gg.babble.babble.controller;
 
 import gg.babble.babble.dto.GameImageResponse;
+import gg.babble.babble.dto.IndexPageGameResponse;
 import gg.babble.babble.service.GameService;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,11 @@ public class GameController {
 
     public GameController(final GameService gameService) {
         this.gameService = gameService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<IndexPageGameResponse>> findIndexPageGames() {
+        return ResponseEntity.ok(gameService.findSortedGames());
     }
 
     @GetMapping(value = "/{gameId}/images")

--- a/back/babble/src/main/java/gg/babble/babble/domain/Game.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/Game.java
@@ -1,6 +1,8 @@
 package gg.babble.babble.domain;
 
+import gg.babble.babble.domain.room.Rooms;
 import java.util.Objects;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -28,6 +30,9 @@ public class Game {
     @NotNull(message = "게임 이미지는 Null 일 수 없습니다.")
     private String image;
 
+    @Embedded
+    private final Rooms rooms = new Rooms();
+
     public Game(final String name) {
         this(null, name, DEFAULT_IMAGE);
     }
@@ -38,6 +43,10 @@ public class Game {
 
     public Game(final String name, final String image) {
         this(null, name, image);
+    }
+
+    public int userHeadCount() {
+        return rooms.totalHeadCount();
     }
 
     @Override

--- a/back/babble/src/main/java/gg/babble/babble/domain/Games.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/Games.java
@@ -1,0 +1,21 @@
+package gg.babble.babble.domain;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class Games {
+
+    private final List<Game> games;
+
+    public Games(final List<Game> games) {
+        this.games = games;
+    }
+
+    public void sortedByHeadCount() {
+        games.sort(Comparator.comparing(Game::userHeadCount).reversed());
+    }
+
+    public List<Game> toList() {
+        return games;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/room/Rooms.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/room/Rooms.java
@@ -1,0 +1,27 @@
+package gg.babble.babble.domain.room;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+
+@Embeddable
+public class Rooms {
+
+    @OneToMany(mappedBy = "game")
+    private final List<Room> rooms;
+
+    public Rooms() {
+        this(new ArrayList<>());
+    }
+
+    public Rooms(final List<Room> rooms) {
+        this.rooms = rooms;
+    }
+
+    public int totalHeadCount() {
+        return rooms.stream()
+            .mapToInt(Room::currentHeadCount)
+            .sum();
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/IndexPageGameResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/IndexPageGameResponse.java
@@ -1,0 +1,29 @@
+package gg.babble.babble.dto;
+
+import gg.babble.babble.domain.Game;
+import gg.babble.babble.domain.Games;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class IndexPageGameResponse {
+
+    private final Long id;
+    private final String name;
+    private final int headCount;
+    private final String thumbnail;
+
+    public static List<IndexPageGameResponse> listFrom(final Games games) {
+        return games.toList()
+            .stream()
+            .map(IndexPageGameResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    private static IndexPageGameResponse from(final Game game) {
+        return new IndexPageGameResponse(game.getId(), game.getName(), game.userHeadCount(), game.getImage());
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/service/GameService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/GameService.java
@@ -1,8 +1,10 @@
 package gg.babble.babble.service;
 
 import gg.babble.babble.domain.Game;
+import gg.babble.babble.domain.Games;
 import gg.babble.babble.domain.repository.GameRepository;
 import gg.babble.babble.dto.GameImageResponse;
+import gg.babble.babble.dto.IndexPageGameResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +28,13 @@ public class GameService {
 
     public List<Game> findByName(final String name) {
         return gameRepository.findByName(name);
+    }
+
+    public List<IndexPageGameResponse> findSortedGames() {
+        Games games = new Games(gameRepository.findAll());
+        games.sortedByHeadCount();
+
+        return IndexPageGameResponse.listFrom(games);
     }
 
     public GameImageResponse findGameImageById(final Long gameId) {

--- a/back/babble/src/test/java/gg/babble/babble/domain/GamesTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/GamesTest.java
@@ -1,0 +1,54 @@
+package gg.babble.babble.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gg.babble.babble.domain.room.MaxHeadCount;
+import gg.babble.babble.domain.room.Room;
+import gg.babble.babble.domain.tag.Tag;
+import gg.babble.babble.domain.user.User;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GamesTest {
+
+    @Test
+    @DisplayName("현재 게임에 참여중인 유저수에 따라 내림차순 정렬을 진행한다.")
+    void sortedListByHeadCount() {
+        // given
+        User 루트 = new User(1L, "루트");
+        User 와일더 = new User(2L, "와일더");
+        User 피터 = new User(3L, "피터");
+        User 그루밍 = new User(4L, "그루밍");
+
+        Game 너구리게임 = new Game(1L, "너구리게임");
+        Room 너구리게임_방 = 게임에_해당하는_방을_생성한다(너구리게임);
+        게임_방에_유저를_입장_시킨다(너구리게임_방, 루트);
+        게임_방에_유저를_입장_시킨다(너구리게임_방, 와일더);
+        게임_방에_유저를_입장_시킨다(너구리게임_방, 그루밍);
+
+        Game 피카츄배구 = new Game(2L, "피카츄배구");
+        Room 피카츄배구_방 = 게임에_해당하는_방을_생성한다(피카츄배구);
+        게임_방에_유저를_입장_시킨다(피카츄배구_방, 피터);
+
+        Games games = new Games(Arrays.asList(너구리게임, 피카츄배구));
+
+        // when
+        games.sortedByHeadCount();
+
+        // then
+        assertThat(games.toList()).containsExactly(너구리게임, 피카츄배구);
+    }
+
+    private void 게임_방에_유저를_입장_시킨다(Room room, User user) {
+        room.join(user);
+    }
+
+    private Room 게임에_해당하는_방을_생성한다(final Game game) {
+        List<Tag> tags = Collections.singletonList(new Tag("good-tag"));
+        MaxHeadCount maxHeadCount = new MaxHeadCount(10);
+        return new Room(1L, game, tags, maxHeadCount);
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/domain/repository/RoomRepositoryTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/repository/RoomRepositoryTest.java
@@ -37,29 +37,6 @@ public class RoomRepositoryTest extends ApplicationTest {
     @Autowired
     private TagService tagService;
 
-    @DisplayName("방 더미 데이터를 확인한다.")
-    @Test
-    void dummyGameTest() {
-        Room room = roomRepository.findAll().get(0);
-
-        Game expectedGame = new Game(LEAGUE_OF_LEGENDS, "https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg");
-        User expectedHost = new User(루트, room);
-
-        List<String> expectedTags = Arrays.asList(실버, _2시간);
-
-        assertThat(room.getCreatedDate()).isNotNull();
-        assertThat(room.getGame()).usingRecursiveComparison()
-            .ignoringFields("id")
-            .isEqualTo(expectedGame);
-        assertThat(room.getHost()).usingRecursiveComparison()
-            .ignoringFields("id")
-            .isEqualTo(expectedHost);
-        assertThat(room.getTagRegistrationsOfRoom().tagNames())
-            .usingRecursiveComparison()
-            .ignoringFields("tagRegistrations")
-            .isEqualTo(expectedTags);
-    }
-
     @DisplayName("생성한 방을 저장한다.")
     @Test
     void saveTest() {

--- a/back/babble/src/test/java/gg/babble/babble/domain/room/RoomsTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/room/RoomsTest.java
@@ -1,0 +1,53 @@
+package gg.babble.babble.domain.room;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gg.babble.babble.domain.Game;
+import gg.babble.babble.domain.tag.Tag;
+import gg.babble.babble.domain.user.User;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RoomsTest {
+
+    @Test
+    @DisplayName("현재 방들에 참여중인 총 유저의 수를 반환한다.")
+    void totalUserCountTest() {
+        // given
+        List<Room> roomList = 방_목록을_생성한다();
+        Rooms rooms = new Rooms(roomList);
+
+        int expectedTotalUserCount = roomList.stream()
+            .mapToInt(Room::currentHeadCount)
+            .sum();
+
+        // when
+        int totalUserCount = rooms.totalHeadCount();
+
+        // then
+        assertThat(totalUserCount).isEqualTo(expectedTotalUserCount);
+    }
+
+    private List<Room> 방_목록을_생성한다() {
+        List<Room> roomList = new ArrayList<>();
+        Game game = new Game(1L, "fun");
+
+        for (int i = 0; i < 5; i++) {
+            Room room = 게임에_해당하는_방을_생성한다(game);
+            User user = new User("익명의 누군가");
+            room.join(user);
+            roomList.add(room);
+        }
+
+        return roomList;
+    }
+
+    private Room 게임에_해당하는_방을_생성한다(final Game game) {
+        List<Tag> tags = Collections.singletonList(new Tag("good-tag"));
+        MaxHeadCount maxHeadCount = new MaxHeadCount(10);
+        return new Room(1L, game, tags, maxHeadCount);
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
@@ -37,6 +37,33 @@ public class GameApiDocumentTest extends ApplicationTest {
             .build();
     }
 
+    @DisplayName("게임 리스트 조회")
+    @Test
+    void findAllGames() throws Exception {
+        mockMvc.perform(get("/api/games")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(1L))
+            .andExpect(jsonPath("$[0].name").value("League Of Legends"))
+            .andExpect(jsonPath("$[0].headCount").value(1))
+            .andExpect(jsonPath("$[0].thumbnail").value("https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg"))
+            .andExpect(jsonPath("$[1].id").value(2L))
+            .andExpect(jsonPath("$[1].name").value("Overwatch"))
+            .andExpect(jsonPath("$[1].headCount").value(0))
+            .andExpect(jsonPath("$[1].thumbnail").value("https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg"))
+            .andExpect(jsonPath("$[2].id").value(3L))
+            .andExpect(jsonPath("$[2].name").value("Apex Legend"))
+            .andExpect(jsonPath("$[2].headCount").value(0))
+            .andExpect(jsonPath("$[2].thumbnail").value("https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg"))
+
+            .andDo(document("read-games",
+                responseFields(
+                    fieldWithPath("[].id").description("게임 Id"),
+                    fieldWithPath("[].name").description("게임 이름"),
+                    fieldWithPath("[].headCount").description("게임의 참가자 수"),
+                    fieldWithPath("[].thumbnail").description("썸네일"))));
+    }
+
     @DisplayName("단일 게임 이미지 조회")
     @Test
     void findGameImageById() throws Exception {
@@ -47,9 +74,9 @@ public class GameApiDocumentTest extends ApplicationTest {
             .andExpect(jsonPath("$.image").value("https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg"))
 
             .andDo(document("read-game-image",
-                    responseFields(
-                        fieldWithPath("gameId").description("게임 Id"),
-                        fieldWithPath("image").description("이미지 URL"))));
+                responseFields(
+                    fieldWithPath("gameId").description("게임 Id"),
+                    fieldWithPath("image").description("이미지 URL"))));
     }
 
     @DisplayName("전체 게임 이미지 목록 조회")

--- a/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import gg.babble.babble.ApplicationTest;
 import gg.babble.babble.dto.GameImageResponse;
+import gg.babble.babble.dto.GameResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.Arrays;
 import java.util.List;
@@ -14,7 +15,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class GameServiceTest extends ApplicationTest {
 
+    private static final String LEAGUE_OF_LEGENDS = "League Of Legends";
+    private static final String OVERWATCH = "Overwatch";
+    private static final String APEX_LEGEND = "Apex Legend";
     private static final String LEAGUE_OF_LEGENDS_URL = "https://static-cdn.jtvnw.net/ttv-boxart/League%20of%20Legends-1080x1436.jpg";
+    private static final String DEFAULT_URL = "https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg";
+
     @Autowired
     private GameService gameService;
 
@@ -48,6 +54,20 @@ class GameServiceTest extends ApplicationTest {
 
         // then
         assertThat(gameService.findAllGameImages()).usingRecursiveComparison()
+            .isEqualTo(expectedResponses);
+    }
+
+    @DisplayName("전체 게임 리스트를 반환한다.")
+    @Test
+    void findAllGames() {
+        // when
+        List<GameForInitResponse> expectedResponses = Arrays.asList(
+          new GameForInitResponse(1L, LEAGUE_OF_LEGENDS, 1, LEAGUE_OF_LEGENDS_URL),
+          new GameForInitResponse(2L, OVERWATCH, 0, DEFAULT_URL),
+          new GameForInitResponse(3L, APEX_LEGEND, 0, DEFAULT_URL)
+        );
+        // then
+        assertThat(gameService.findAll()).usingRecursiveComparison()
             .isEqualTo(expectedResponses);
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import gg.babble.babble.ApplicationTest;
 import gg.babble.babble.dto.GameImageResponse;
 import gg.babble.babble.dto.GameResponse;
+import gg.babble.babble.dto.IndexPageGameResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.Arrays;
 import java.util.List;
@@ -61,13 +62,13 @@ class GameServiceTest extends ApplicationTest {
     @Test
     void findAllGames() {
         // when
-        List<GameForInitResponse> expectedResponses = Arrays.asList(
-          new GameForInitResponse(1L, LEAGUE_OF_LEGENDS, 1, LEAGUE_OF_LEGENDS_URL),
-          new GameForInitResponse(2L, OVERWATCH, 0, DEFAULT_URL),
-          new GameForInitResponse(3L, APEX_LEGEND, 0, DEFAULT_URL)
+        List<IndexPageGameResponse> expectedResponses = Arrays.asList(
+          new IndexPageGameResponse(1L, LEAGUE_OF_LEGENDS, 1, LEAGUE_OF_LEGENDS_URL),
+          new IndexPageGameResponse(2L, OVERWATCH, 0, DEFAULT_URL),
+          new IndexPageGameResponse(3L, APEX_LEGEND, 0, DEFAULT_URL)
         );
         // then
-        assertThat(gameService.findAll()).usingRecursiveComparison()
+        assertThat(gameService.findSortedGames()).usingRecursiveComparison()
             .isEqualTo(expectedResponses);
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/GameServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import gg.babble.babble.ApplicationTest;
 import gg.babble.babble.dto.GameImageResponse;
-import gg.babble.babble.dto.GameResponse;
 import gg.babble.babble.dto.IndexPageGameResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.Arrays;
@@ -63,9 +62,9 @@ class GameServiceTest extends ApplicationTest {
     void findAllGames() {
         // when
         List<IndexPageGameResponse> expectedResponses = Arrays.asList(
-          new IndexPageGameResponse(1L, LEAGUE_OF_LEGENDS, 1, LEAGUE_OF_LEGENDS_URL),
-          new IndexPageGameResponse(2L, OVERWATCH, 0, DEFAULT_URL),
-          new IndexPageGameResponse(3L, APEX_LEGEND, 0, DEFAULT_URL)
+            new IndexPageGameResponse(1L, LEAGUE_OF_LEGENDS, 1, LEAGUE_OF_LEGENDS_URL),
+            new IndexPageGameResponse(2L, OVERWATCH, 0, DEFAULT_URL),
+            new IndexPageGameResponse(3L, APEX_LEGEND, 0, DEFAULT_URL)
         );
         // then
         assertThat(gameService.findSortedGames()).usingRecursiveComparison()


### PR DESCRIPTION
## 🔥 구현 내용 요약
- 게임에 참가중인 인원 수에 따라 내림차순 정렬된 게임 리스트를 반환하도록 했습니다.

## 🤔  고민 중인 사항
- 도메인 테스트 부족한 부분이 없는지 확실하지 않네요...
- 양방향 매핑이 제대로 이루어졌는지 확인이 미흡합니다.
- 일급 컬렉션으로 로직이 서비스 레이어로 노출되지 않게 최대한 숨겨봤는데, 괜찮을까요?