### PR TITLE
feat: 태그 Id 추가

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/DataLoader.java
+++ b/back/babble/src/main/java/gg/babble/babble/DataLoader.java
@@ -83,8 +83,8 @@ public class DataLoader implements CommandLineRunner {
         Game game = gameRepository.findByName(LEAGUE_OF_LEGENDS).get(FIRST_DATA_INDEX);
         User user = userRepository.findByNickname(루트).get(FIRST_DATA_INDEX);
         List<Tag> tags = Arrays
-            .asList(tagRepository.findById(실버).orElseThrow(BabbleNotFoundException::new),
-                tagRepository.findById(_2시간).orElseThrow(BabbleNotFoundException::new));
+            .asList(tagRepository.findByName(실버).get(0),
+                tagRepository.findByName(_2시간).get(0));
 
         Room room = new Room(game, tags, new MaxHeadCount(4));
 

--- a/back/babble/src/main/java/gg/babble/babble/domain/repository/TagRepository.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/repository/TagRepository.java
@@ -1,8 +1,10 @@
 package gg.babble.babble.domain.repository;
 
 import gg.babble.babble.domain.tag.Tag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TagRepository extends JpaRepository<Tag, String> {
+public interface TagRepository extends JpaRepository<Tag, Long> {
 
+    List<Tag> findByName (String name);
 }

--- a/back/babble/src/main/java/gg/babble/babble/domain/room/TagRegistrationsOfRoom.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/room/TagRegistrationsOfRoom.java
@@ -26,9 +26,9 @@ public class TagRegistrationsOfRoom {
             .collect(Collectors.toList());
     }
 
-    public List<String> tagNames() {
+    public List<Tag> tags() {
         return tagRegistrations.stream()
-            .map(tagRegistration -> tagRegistration.getTag().getName())
+            .map(TagRegistration::getTag)
             .collect(Collectors.toList());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/Tag.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/Tag.java
@@ -4,8 +4,12 @@ import gg.babble.babble.exception.BabbleLengthException;
 import java.util.Objects;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,13 +19,22 @@ import lombok.NoArgsConstructor;
 public class Tag {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull(message = "태그 이름은 Null 일 수 없습니다.")
     private String name;
 
     @Embedded
     private TagRegistrationsOfTag tagRegistrations;
 
     public Tag(final String name) {
+        this(null, name);
+    }
+
+    public Tag(final Long id, final String name) {
         validateToConstruct(name);
+        this.id = id;
         this.name = name;
         this.tagRegistrations = new TagRegistrationsOfTag();
     }

--- a/back/babble/src/main/java/gg/babble/babble/dto/CreatedRoomResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/CreatedRoomResponse.java
@@ -30,9 +30,9 @@ public class CreatedRoomResponse {
     }
 
     private static List<TagResponse> tagResponses(TagRegistrationsOfRoom tagRegistrations) {
-        return tagRegistrations.tagNames()
+        return tagRegistrations.tags()
             .stream()
-            .map(TagResponse::new)
+            .map(TagResponse::from)
             .collect(Collectors.toList());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/dto/FoundRoomResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/FoundRoomResponse.java
@@ -32,9 +32,9 @@ public class FoundRoomResponse {
     }
 
     private static List<TagResponse> tagResponses(final TagRegistrationsOfRoom tagRegistrations) {
-        return tagRegistrations.tagNames()
+        return tagRegistrations.tags()
             .stream()
-            .map(TagResponse::new)
+            .map(TagResponse::from)
             .collect(Collectors.toList());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/dto/TagRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/TagRequest.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TagRequest {
 
-    @NotNull(message = "태그 이름은 Null 일 수 없습니다.")
-    private String name;
+    @NotNull(message = "태그 Id는 Null 일 수 없습니다.")
+    private Long id;
 }

--- a/back/babble/src/main/java/gg/babble/babble/dto/TagResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/TagResponse.java
@@ -10,9 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TagResponse {
 
+    private Long id;
     private String name;
 
     public static TagResponse from(final Tag tag) {
-        return new TagResponse(tag.getName());
+        return new TagResponse(tag.getId(), tag.getName());
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/service/TagService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/TagService.java
@@ -20,14 +20,18 @@ public class TagService {
         this.tagRepository = tagRepository;
     }
 
-    public Tag findById(final String name) {
-        return tagRepository.findById(name)
+    public Tag findById(final Long id) {
+        return tagRepository.findById(id)
             .orElseThrow(() -> new BabbleNotFoundException("존재하지 않는 태그입니다."));
+    }
+
+    public List<Tag> findByName(final String name) {
+        return tagRepository.findByName(name);
     }
 
     public List<Tag> findById(final List<TagRequest> tagRequests) {
         return tagRequests.stream()
-            .map(tagRequest -> findById(tagRequest.getName()))
+            .map(tagRequest -> findById(tagRequest.getId()))
             .collect(Collectors.toList());
     }
 

--- a/back/babble/src/test/java/gg/babble/babble/domain/repository/RoomRepositoryTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/repository/RoomRepositoryTest.java
@@ -49,8 +49,8 @@ public class RoomRepositoryTest extends ApplicationTest {
     private Room saveRoom() {
         Game game = gameService.findByName(LEAGUE_OF_LEGENDS).get(0);
         User user = userService.findByNickname(루트).get(0);
-        List<Tag> tags = Arrays.asList(tagService.findById(실버),
-            tagService.findById(_2시간));
+        List<Tag> tags = Arrays.asList(tagService.findByName(실버).get(0),
+            tagService.findByName(_2시간).get(0));
 
         Room room = roomRepository.save(new Room(game, tags, new MaxHeadCount(4)));
 

--- a/back/babble/src/test/java/gg/babble/babble/domain/repository/TagRepositoryTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/repository/TagRepositoryTest.java
@@ -17,6 +17,6 @@ public class TagRepositoryTest extends ApplicationTest {
     @ParameterizedTest
     @ValueSource(strings = {"실버", "2시간", "솔로랭크"})
     void dummyGameTest(final String tagName) {
-        assertThat(tagRepository.existsById(tagName)).isTrue();
+        assertThat(tagRepository.findByName(tagName)).isNotEmpty();
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/RoomApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/RoomApiDocumentTest.java
@@ -64,7 +64,7 @@ public class RoomApiDocumentTest extends ApplicationTest {
         body.put("gameId", 1L);
         body.put("maxHeadCount", 20);
         body.put("tags",
-            Arrays.asList(new TagRequest("실버"), new TagRequest("2시간"), new TagRequest("솔로랭크"))
+            Arrays.asList(new TagRequest(1L), new TagRequest(2L), new TagRequest(3L))
         );
         mockMvc.perform(post("/api/rooms")
             .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -79,19 +79,23 @@ public class RoomApiDocumentTest extends ApplicationTest {
             .andExpect(jsonPath("$.tags").isArray())
             .andExpect(jsonPath("$.tags", hasSize(3)))
             .andExpect(jsonPath("$.maxHeadCount").value(20))
+            .andExpect(jsonPath("$.tags[0].id").value(1L))
             .andExpect(jsonPath("$.tags[0].name").value("실버"))
+            .andExpect(jsonPath("$.tags[1].id").value(2L))
             .andExpect(jsonPath("$.tags[1].name").value("2시간"))
+            .andExpect(jsonPath("$.tags[2].id").value(3L))
             .andExpect(jsonPath("$.tags[2].name").value("솔로랭크"))
 
             .andDo(document("create-room",
                 requestFields(fieldWithPath("gameId").description("게임 Id"),
                     fieldWithPath("maxHeadCount").description("최대 참가 인원"),
-                    fieldWithPath("tags[].name").description("태그 리스트")),
+                    fieldWithPath("tags[].id").description("태그 Id")),
                 responseFields(fieldWithPath("roomId").description("방 Id"),
                     fieldWithPath("createdDate").description("방 생성 시각"),
                     fieldWithPath("game.id").description("게임 Id"),
                     fieldWithPath("game.name").description("게임 이름"),
                     fieldWithPath("maxHeadCount").description("최대 참가 인원"),
+                    fieldWithPath("tags[].id").description("태그 Id"),
                     fieldWithPath("tags[].name").description("태그 리스트"))));
     }
 
@@ -112,7 +116,9 @@ public class RoomApiDocumentTest extends ApplicationTest {
             .andExpect(jsonPath("$.headCount.max").isNumber())
             .andExpect(jsonPath("$.tags").isArray())
             .andExpect(jsonPath("$.tags", hasSize(2)))
+            .andExpect(jsonPath("$.tags[0].id").value(1L))
             .andExpect(jsonPath("$.tags[0].name").value("실버"))
+            .andExpect(jsonPath("$.tags[1].id").value(2L))
             .andExpect(jsonPath("$.tags[1].name").value("2시간"))
 
             .andDo(document("read-room",
@@ -125,6 +131,7 @@ public class RoomApiDocumentTest extends ApplicationTest {
                     fieldWithPath("host.avatar").description("호스트 아바타"),
                     fieldWithPath("headCount.current").description("현재 참가 인원"),
                     fieldWithPath("headCount.max").description("최대 참가 인원"),
-                    fieldWithPath("tags[].name").description("태그 리스트"))));
+                    fieldWithPath("tags[].id").description("태그 Id"),
+                    fieldWithPath("tags[].name").description("태그 이름"))));
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/TagApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/TagApiDocumentTest.java
@@ -47,12 +47,17 @@ public class TagApiDocumentTest extends AcceptanceTest {
             .andExpect(jsonPath("$").exists())
             .andExpect(jsonPath("$").isArray())
             .andExpect(jsonPath("$", hasSize(3)))
-            .andExpect(jsonPath("$.[0].name").value("2시간"))
-            .andExpect(jsonPath("$.[1].name").value("솔로랭크"))
-            .andExpect(jsonPath("$.[2].name").value("실버"))
+            .andExpect(jsonPath("$.[0].id").value(1L))
+            .andExpect(jsonPath("$.[0].name").value("실버"))
+            .andExpect(jsonPath("$.[1].id").value(2L))
+            .andExpect(jsonPath("$.[1].name").value("2시간"))
+            .andExpect(jsonPath("$.[2].id").value(3L))
+            .andExpect(jsonPath("$.[2].name").value("솔로랭크"))
+
 
             .andDo(document("tags-get",
                 responseFields(
+                    fieldWithPath("[].id").description("태그 Id"),
                     fieldWithPath("[].name").description("태그 이름"))));
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/RoomServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/RoomServiceTest.java
@@ -45,8 +45,8 @@ class RoomServiceTest extends ApplicationTest {
 
         Game game = gameService.findByName(LEAGUE_OF_LEGENDS).get(0);
         User user = userService.findByNickname(루트).get(0);
-        List<Tag> tags = Arrays.asList(tagService.findById(실버),
-            tagService.findById(_2시간));
+        List<Tag> tags = Arrays.asList(tagService.findByName(실버).get(0),
+            tagService.findByName(_2시간).get(0));
         FoundRoomResponse expected = FoundRoomResponse.builder()
             .roomId(1L)
             .game(new GameResponse(game.getId(), game.getName()))
@@ -62,7 +62,7 @@ class RoomServiceTest extends ApplicationTest {
 
     private List<TagResponse> tagResponsesFromTags(final List<Tag> tags) {
         return tags.stream()
-            .map(tag -> new TagResponse(tag.getName()))
+            .map(TagResponse::from)
             .collect(Collectors.toList());
     }
 

--- a/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
@@ -8,6 +8,7 @@ import gg.babble.babble.dto.TagResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +42,7 @@ public class TagServiceTest extends ApplicationTest {
     @DisplayName("존재하지 않는 태그면 예외 처리한다.")
     @Test
     void tagNotFoundTest() {
-        assertThatThrownBy(() -> tagService.findById("쏙옙뷁훑"))
+        assertThatThrownBy(() -> tagService.findById(Long.MAX_VALUE))
             .isInstanceOf(BabbleNotFoundException.class);
     }
 
@@ -50,14 +51,13 @@ public class TagServiceTest extends ApplicationTest {
     void getAllTags() {
 
         // given
-        List<TagResponse> expectedTags = Arrays.asList(
-            new TagResponse("2시간"),
-            new TagResponse("솔로랭크"),
-            new TagResponse("실버")
-        );
+        List<String> expectedTags = Arrays.asList("실버", "2시간", "솔로랭크");
 
         // when
-        List<TagResponse> allTags = tagService.getAllTags();
+        List<String> allTags = tagService.getAllTags()
+            .stream()
+            .map(TagResponse::getName)
+            .collect(Collectors.toList());
 
         // then
         assertThat(expectedTags).usingRecursiveComparison().isEqualTo(allTags);


### PR DESCRIPTION
Closes #

## 🔥 구현 내용 요약

태그 이름을 Id로 사용하고 있던 것을 별도의 Integer Id를 사용하도록 수정했습니다.

## ☠ 트러블 슈팅

따로 없었지만, DataLoader와 테스트 코드의 분리의 필요성을 느꼈습니다.
