### PR TITLE
feat: 방 생성 페이지 마크업 마무리

### DIFF
--- a/front/index.js
+++ b/front/index.js
@@ -4,10 +4,13 @@ import App from './src/App';
 import ModalProvider from './src/contexts/ModalProvider';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 ReactDOM.render(
   <ModalProvider>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </ModalProvider>,
   document.getElementById('root')
 );

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1292,7 +1292,6 @@
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
       "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -13762,6 +13761,19 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -13777,7 +13789,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -15668,6 +15679,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -19191,7 +19211,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -19673,8 +19692,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -19708,6 +19726,52 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "dev": true
+    },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
     },
     "react-select": {
       "version": "3.2.0",
@@ -19912,8 +19976,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -20223,6 +20286,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -22114,6 +22182,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -22751,6 +22829,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -57,6 +57,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
+    "react-router-dom": "^5.2.0",
     "sass": "^1.35.2",
     "sockjs-client": "^1.5.1"
   },

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -1,10 +1,12 @@
 import '../global.scss';
 
+import MakeRoom from './pages/MakeRoom/MakeRoom';
 import React from 'react';
-import RoomList from './pages/RoomList/RoomList';
+
+// import RoomList from './pages/RoomList/RoomList';
 
 const App = () => {
-  return <RoomList />;
+  return <MakeRoom />;
 };
 
 export default App;

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -1,12 +1,14 @@
 import '../global.scss';
 
-import MakeRoom from './pages/MakeRoom/MakeRoom';
 import React from 'react';
+import RoomList from './pages/RoomList/RoomList';
 
-// import RoomList from './pages/RoomList/RoomList';
+// import { Link, Route, Switch } from 'react-router-dom';
+
+// import MakeRoom from './pages/MakeRoom/MakeRoom';
 
 const App = () => {
-  return <MakeRoom />;
+  return <RoomList />;
 };
 
 export default App;

--- a/front/src/chunks/TagList/TagList.scss
+++ b/front/src/chunks/TagList/TagList.scss
@@ -5,6 +5,7 @@
   &.default {
     .linear-layout {
       flex-wrap: wrap;
+      gap: 1rem 0;
     }
   }
 

--- a/front/src/components/Button/Button.scss
+++ b/front/src/components/Button/Button.scss
@@ -12,6 +12,10 @@
 }
 
 button {
+  &.tiny {
+    padding: m.button-padding(tiny);
+  }
+
   &.small {
     padding: m.button-padding(small);
   }

--- a/front/src/components/Button/Button.stories.js
+++ b/front/src/components/Button/Button.stories.js
@@ -20,6 +20,9 @@ const SquareButtonTemplate = () => (
         width: '54rem',
       }}
     >
+      <SquareButton size='tiny'>
+        <Caption2>방 생성하기</Caption2>
+      </SquareButton>
       <SquareButton size='small'>
         <Caption2>방 생성하기</Caption2>
       </SquareButton>
@@ -31,7 +34,7 @@ const SquareButtonTemplate = () => (
       </SquareButton>
     </div>
     <br />
-    <div style={{ width: '54rem', height: '9rem', padding: '1rem 2rem' }}>
+    <div style={{ width: '54rem', height: '9rem', padding: '1rem 0' }}>
       <SquareButton size='block'>
         <Body1>방 생성하기</Body1>
       </SquareButton>
@@ -45,6 +48,9 @@ const SquareButtonTemplate = () => (
         width: '54rem',
       }}
     >
+      <SquareButton size='tiny' colored={false}>
+        <Caption2>방 생성하기</Caption2>
+      </SquareButton>
       <SquareButton size='small' colored={false}>
         <Caption2>방 생성하기</Caption2>
       </SquareButton>
@@ -56,7 +62,7 @@ const SquareButtonTemplate = () => (
       </SquareButton>
     </div>
     <br />
-    <div style={{ width: '54rem', height: '9rem', padding: '1rem 2rem' }}>
+    <div style={{ width: '54rem', height: '9rem', padding: '1rem 0' }}>
       <SquareButton size='block' colored={false}>
         <Body1>방 생성하기</Body1>
       </SquareButton>
@@ -74,6 +80,9 @@ const RoundButtonTemplate = () => (
         width: '54rem',
       }}
     >
+      <RoundButton size='tiny' colored={true}>
+        <Caption2>방 생성하기</Caption2>
+      </RoundButton>
       <RoundButton size='small' colored={true}>
         <Caption2>방 생성하기</Caption2>
       </RoundButton>
@@ -85,7 +94,7 @@ const RoundButtonTemplate = () => (
       </RoundButton>
     </div>
     <br />
-    <div style={{ width: '54rem', height: '9rem', padding: '1rem 2rem' }}>
+    <div style={{ width: '54rem', height: '9rem', padding: '1rem 0' }}>
       <RoundButton size='block' colored={true}>
         <Body1>방 생성하기</Body1>
       </RoundButton>
@@ -99,6 +108,9 @@ const RoundButtonTemplate = () => (
         width: '54rem',
       }}
     >
+      <RoundButton size='tiny'>
+        <Caption2>방 생성하기</Caption2>
+      </RoundButton>
       <RoundButton size='small'>
         <Caption2>방 생성하기</Caption2>
       </RoundButton>
@@ -110,7 +122,7 @@ const RoundButtonTemplate = () => (
       </RoundButton>
     </div>
     <br />
-    <div style={{ width: '54rem', height: '9rem', padding: '1rem 2rem' }}>
+    <div style={{ width: '54rem', height: '9rem', padding: '1rem 0' }}>
       <RoundButton size='block'>
         <Body1>방 생성하기</Body1>
       </RoundButton>

--- a/front/src/components/Modal/Modal.scss
+++ b/front/src/components/Modal/Modal.scss
@@ -3,6 +3,7 @@
 
 .modal-container {
   position: fixed;
+  z-index: m.z-index(layer-modal-dimmer);
 
   &.default {
     width: 100%;
@@ -17,6 +18,7 @@
 
     .linear-layout {
       justify-content: center;
+      z-index: m.z-index(layer-modal);
     }
   }
 
@@ -30,6 +32,7 @@
     border: 1px solid m.grey-scale(8);
     border-radius: m.border-radius(modal);
     box-shadow: v.$box-shadow;
+    z-index: m.z-index(layer-modal);
 
     & > section {
       width: 100%;
@@ -45,6 +48,7 @@
   right: 2rem;
   bottom: -0.5rem;
   cursor: pointer;
+  z-index: m.z-index(layer-modal);
 
   background: linear-gradient(
     60deg,

--- a/front/src/components/Room/Room.scss
+++ b/front/src/components/Room/Room.scss
@@ -12,7 +12,7 @@
   transition: ease-in 0.1s;
 
   &:hover {
-    transform: scaleX(1.01) scaleY(1.03);
+    transform: scale(1.01);
   }
 
   .information {
@@ -47,7 +47,7 @@
   }
 
   &:active {
-    transform: scale(0.96);
-    transition: transform 70ms ease-in;
+    transform: scale(0.99);
+    transition: transform 10ms ease-in;
   }
 }

--- a/front/src/components/SearchInput/DropdownInput.js
+++ b/front/src/components/SearchInput/DropdownInput.js
@@ -32,11 +32,6 @@ const DropdownInput = ({
     dropdownRef.current.classList.remove('show');
   };
 
-  const onClickArrowDown = () => {
-    containerRef.current.classList.toggle('focused');
-    dropdownRef.current.classList.toggle('show');
-  };
-
   useEffect(() => {
     setDropdownList(dropdownKeywords);
   }, []);
@@ -52,7 +47,7 @@ const DropdownInput = ({
         ref={inputRef}
         readOnly
       />
-      <IoCaretDown size='20px' onClick={onClickArrowDown} />
+      <IoCaretDown size='20px' />
       <ul className='keyword-list-container' ref={dropdownRef}>
         {dropdownList.length ? (
           dropdownList.map((dropdownItem, index) => (

--- a/front/src/pages/MakeRoom/MakeRoom.js
+++ b/front/src/pages/MakeRoom/MakeRoom.js
@@ -1,22 +1,21 @@
 import './MakeRoom.scss';
 
+import Body2 from '../../core/Typography/Body2';
 import DropdownInput from '../../components/SearchInput/DropdownInput';
+import Headline2 from '../../core/Typography/Headline2';
 import MainImage from '../../components/MainImage/MainImage';
 import PageLayout from '../../core/Layout/PageLayout';
 import React from 'react';
 import RoundButton from '../../components/Button/RoundButton';
 import SearchInput from '../../components/SearchInput/SearchInput';
-import Subtitle1 from '../../core/Typography/Subtitle1';
 import TagList from '../../chunks/TagList/TagList';
-
-// import PropTypes from 'prop-types';
 
 const MakeRoom = () => {
   return (
     <main className='make-room-container'>
       <MainImage />
       <PageLayout type='narrow'>
-        <Subtitle1>방 생성하기</Subtitle1>
+        <Headline2>방 생성하기</Headline2>
         <section className='inputs'>
           <DropdownInput dropdownKeywords={[]} />
           <SearchInput autoCompleteKeywords={[]} />
@@ -30,13 +29,15 @@ const MakeRoom = () => {
               { name: '솔로랭크' },
               { name: '음성채팅 가능' },
             ]}
-            tagType='erasable'
+            erasable
           />
         </section>
         <section className='buttons'>
-          <RoundButton size='small'>취소하기</RoundButton>
+          <RoundButton size='small'>
+            <Body2>취소하기</Body2>
+          </RoundButton>
           <RoundButton colored={true} size='small'>
-            생성하기
+            <Body2>생성하기</Body2>
           </RoundButton>
         </section>
       </PageLayout>

--- a/front/src/pages/MakeRoom/MakeRoom.scss
+++ b/front/src/pages/MakeRoom/MakeRoom.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   align-items: center;
 
-  .subtitle1 {
+  .headline2 {
     margin: 4rem 0;
   }
 
@@ -18,11 +18,11 @@
 
   .tag-list-section {
     width: 100%;
-    min-height: 4rem;
-    margin-bottom: 4rem;
+    min-height: 2rem;
+    margin-bottom: 5rem;
 
     .linear-layout {
-      justify-content: center;
+      justify-content: flex-start;
     }
   }
 

--- a/front/style/_variables.scss
+++ b/front/style/_variables.scss
@@ -62,4 +62,6 @@ $z-index: (
   layer-back-1: -1,
   layer-middle: 0,
   layer-front-1: 1,
+  layer-modal-dimmer: 998,
+  layer-modal: 999,
 );

--- a/front/style/_variables.scss
+++ b/front/style/_variables.scss
@@ -13,7 +13,8 @@ $border-radius: (
 );
 
 $button-padding: (
-  small: 0.6rem 1.8rem,
+  tiny: 0.6rem 1.8rem,
+  small: 0.8rem 2.2rem,
   medium: 1.4rem 2.6rem,
   large: 1.8rem 4rem,
 );


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
![image](https://user-images.githubusercontent.com/42052110/127341861-9dd416f5-64ee-4fa7-b6be-2150ed3cd690.png)

## 🔥 구현 내용 요약
- 제일 작은 버튼 컴포넌트 추가
- Dropdown Input의 화살표를 클릭해도 더 이상 input이 focus 되지 않음
- TagList가 여러 줄이 될 경우에 gap 추가, 태그 정렬을 좌측 정렬로 수정
- Modal에 z-index를 추가
- 방 컴포넌트에 hover, active 애니메이션 추가
- 방 생성하기 제목 크기 확대

## ☠ 트러블 슈팅
- 마크업이라 딱히 음슴 ㅋ