### PR TITLE
fix: api-docs가 덮어쓰기 되도록 수정

### DIFF
--- a/back/babble/build.gradle
+++ b/back/babble/build.gradle
@@ -56,6 +56,10 @@ test {
 	useJUnitPlatform()
 }
 
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
+
 asciidoctor {
 	attributes 'snippets': snippetsDir
 	inputs.dir snippetsDir


### PR DESCRIPTION
## 🔥 구현 내용 요약

api-docs가 덮어쓰기 되도록 수정


## ☠ 트러블 슈팅

없음