### PR TITLE
fix: unsubscribe 이전에 퇴장 메시지를 send하도록 수정

### DIFF
--- a/front/src/pages/ChattingRoom/ChattingRoom.js
+++ b/front/src/pages/ChattingRoom/ChattingRoom.js
@@ -73,6 +73,8 @@ const ChattingRoom = ({ tags, roomId, createdAt }) => {
     getUserId();
 
     return () => {
+      sendMessage(`${nickname} 님이 퇴장했습니다!`);
+
       if (user_subscription.current) {
         user_subscription.current.unsubscribe();
       }
@@ -80,7 +82,6 @@ const ChattingRoom = ({ tags, roomId, createdAt }) => {
         chat_subscription.current.unsubscribe();
       }
       if (isConnected.current) {
-        sendMessage(`${nickname} 님이 퇴장했습니다!`);
         stompClient.current.disconnect();
         isConnected.current = false;
       }


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약
- unsubscribe 이전에 퇴장 메시지를 출력하도록 수정

## ☠ 트러블 슈팅
