### PR TITLE
fix: 웹소켓 채팅 send 시 readyState가 OPEN 상태일 때만 전송하도록 수정

### DIFF
--- a/.github/workflows/front-main.yml
+++ b/.github/workflows/front-main.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: 배포
         working-directory: ./front
-        run: aws s3 sync ./dist s3://bucket-babble-front/
+        run: aws s3 sync ./dist s3://bucket-babble-front/ --delete

--- a/.github/workflows/front-release.yml
+++ b/.github/workflows/front-release.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: 배포
         working-directory: ./front
-        run: aws s3 sync ./dist s3://bucket-babble-front/
+        run: aws s3 sync ./dist s3://bucket-babble-front/ --delete

--- a/front/src/components/NicknameSection/NicknameSection.js
+++ b/front/src/components/NicknameSection/NicknameSection.js
@@ -5,12 +5,18 @@ import Caption1 from '../../core/Typography/Caption1';
 import Caption2 from '../../core/Typography/Caption2';
 import ChangeNickname from '../../pages/ChangeNickname/ChangeNickname';
 import { FiEdit } from 'react-icons/fi';
-import PropTypes from 'prop-types';
 import React from 'react';
+import { useChattingModal } from '../../contexts/ChattingModalProvider';
 import { useDefaultModal } from '../../contexts/DefaultModalProvider';
+import { useUser } from '../../contexts/UserProvider';
 
-const NicknameSection = ({ nickname }) => {
+const NicknameSection = () => {
   const { openModal } = useDefaultModal();
+  const { isChattingModalOpen } = useChattingModal();
+  const {
+    user: { nickname },
+    isNicknameChanged,
+  } = useUser();
 
   const openNicknameModal = () => {
     openModal(<ChangeNickname />);
@@ -18,22 +24,22 @@ const NicknameSection = ({ nickname }) => {
 
   return (
     <section className='nickname-section-container'>
-      {nickname && (
+      {!isNicknameChanged && (
         <div className='notice-bubble'>
           <Caption2>닉네임을 변경해주세요!</Caption2>
         </div>
       )}
       <Body2>{nickname}</Body2>
-      <button className='edit' onClick={openNicknameModal}>
-        <FiEdit size='18px' />
+      <button
+        className='edit'
+        onClick={openNicknameModal}
+        disabled={isChattingModalOpen}
+      >
+        <FiEdit size='16px' />
       </button>
       <Caption1>님 안녕하세요!</Caption1>
     </section>
   );
-};
-
-NicknameSection.propTypes = {
-  nickname: PropTypes.string,
 };
 
 export default NicknameSection;

--- a/front/src/components/NicknameSection/NicknameSection.scss
+++ b/front/src/components/NicknameSection/NicknameSection.scss
@@ -6,6 +6,7 @@
   width: fit-content;
   display: flex;
   position: relative;
+  align-items: center;
 
   .notice-bubble {
     display: inline-block;
@@ -51,6 +52,15 @@
 
   .edit {
     margin: 0 1rem 0 0.5rem;
+    display: flex;
+    align-items: center;
+
+    &:disabled {
+      svg {
+        color: m.grey-scale(5);
+        cursor: default;
+      }
+    }
 
     svg {
       color: m.grey-scale(12);

--- a/front/src/contexts/ChattingModalProvider.js
+++ b/front/src/contexts/ChattingModalProvider.js
@@ -41,9 +41,10 @@ const ChattingModalProvider = ({ children }) => {
     setIsMinimized(false);
   };
 
+  // TODO: 데모데이 이후 isChattingModalOpen 없애기
   return (
     <ChattingModalContext.Provider
-      value={{ openChatting, closeChatting, minimize }}
+      value={{ openChatting, closeChatting, minimize, isChattingModalOpen }}
     >
       {children}
       {isChattingModalOpen && (

--- a/front/src/contexts/UserProvider.js
+++ b/front/src/contexts/UserProvider.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 const UserContext = createContext();
 
 const UserProvider = ({ children }) => {
+  // TODO: 데모데이 이후 isNicknameChanged 삭제하고 더 나은 방법 찾아보기
+  const [isNicknameChanged, setIsNicknameChanged] = useState(false);
   const [user, setUser] = useState({
     id: -1,
     nickname: '',
@@ -25,7 +27,14 @@ const UserProvider = ({ children }) => {
 
   return (
     <UserContext.Provider
-      value={{ user, changeUserId, changeUserNickname, changeAvatar }}
+      value={{
+        user,
+        changeUserId,
+        changeUserNickname,
+        changeAvatar,
+        isNicknameChanged,
+        setIsNicknameChanged,
+      }}
     >
       {children}
     </UserContext.Provider>

--- a/front/src/pages/ChangeNickname/ChangeNickname.js
+++ b/front/src/pages/ChangeNickname/ChangeNickname.js
@@ -11,12 +11,13 @@ import { useUser } from '../../contexts/UserProvider';
 
 const ChangeNickname = () => {
   const { closeModal } = useDefaultModal();
-  const { user, changeUserNickname } = useUser();
+  const { user, changeUserNickname, setIsNicknameChanged } = useUser();
 
   const submitNickname = (e) => {
     e.preventDefault();
     const nicknameInput = e.target.nickname.value;
 
+    setIsNicknameChanged(true);
     changeUserNickname(nicknameInput);
     closeModal();
   };

--- a/front/src/pages/RoomList/RoomList.js
+++ b/front/src/pages/RoomList/RoomList.js
@@ -25,7 +25,7 @@ const RoomList = ({ gameId }) => {
   const [tagList, setTagList] = useState([]);
   const [selectedTagList, setSelectedTagList] = useState([]);
   const [roomList, setRoomList] = useState([]);
-  const { user, changeUserNickname } = useUser();
+  const { changeUserNickname } = useUser();
   const { openChatting, closeChatting } = useChattingModal();
 
   const getImage = async () => {
@@ -130,7 +130,7 @@ const RoomList = ({ gameId }) => {
         <section className='room-list-header'>
           <Headline2>{'League of Legends'}</Headline2>
           <div className='side'>
-            <NicknameSection nickname={user.nickname} />
+            <NicknameSection />
             <Link to={PATH.MAKE_ROOM}>
               <SquareButton size='medium' colored>
                 <Body2>방 생성하기</Body2>


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
![image](https://user-images.githubusercontent.com/42052110/127781322-d535889b-b8bf-496b-a766-6bb424b2f954.png)

## 🔥 구현 내용 요약
- 웹소켓 readyState가 OPEN일 때를 기다리는 waitForConnectionReady 메소드 추가
- sendMessage 메소드 추상화
- 채팅창 모달이 열려있을 때 닉네임 변경이 불가능하도록 수정
- 닉네임 변경을 요구하는 말풍선이 최초 닉네임 변경 이후 보이지 않도록 수정

## ☠ 트러블 슈팅
- StompJS v5가 connect 시와 disconnect 시 각각 다른 sessionId를 서버에 전달한다.
- 서버에서는 connect 시에 전달받은 sessionId를 가지고 해당 유저의 disconnect 여부를 판단하기 때문에 로직이 제대로 작동하지 않는다.
- StompJS v4로 다시 마이그레이션 후 send의 정확도 보강을 위해 waitForConnectionReady 메소드를 추가하였다.