### PR TITLE
fix: 방 생성 후 방 목록 페이지 재입장 시 닉네임이 변경되는 문제 수정

### DIFF
--- a/front/src/contexts/UserProvider.js
+++ b/front/src/contexts/UserProvider.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -24,6 +24,19 @@ const UserProvider = ({ children }) => {
   const changeAvatar = (avatarUrl) => {
     setUser((prevState) => ({ ...prevState, avatar: avatarUrl }));
   };
+
+  const generateSixDigits = () => {
+    // 닉네임에만 쓰일 숫자(userId와 관련 없음) 익명#84729384
+    // TODO: 지금은 숫자로 퉁치지만, 시간 나면 바로 형용사 + 명사 랜덤 매칭
+    // { noun: '너구리', image: '너구리 사진' }
+    // 라이브러리 npm 배포 가능
+    return Math.floor(100000 + Math.random() * 90000);
+  };
+
+  useEffect(() => {
+    // TODO: localStorage로 새로고침 후에도 닉네임 유지되도록 관리
+    changeUserNickname(`익명#${generateSixDigits()}`);
+  }, []);
 
   return (
     <UserContext.Provider

--- a/front/src/pages/RoomList/RoomList.js
+++ b/front/src/pages/RoomList/RoomList.js
@@ -18,14 +18,12 @@ import TagList from '../../chunks/TagList/TagList';
 import axios from 'axios';
 import { useChattingModal } from '../../contexts/ChattingModalProvider';
 import useInterval from '../../hooks/useInterval';
-import { useUser } from '../../contexts/UserProvider';
 
 const RoomList = ({ gameId }) => {
   const [imageUrl, setImageUrl] = useState('');
   const [tagList, setTagList] = useState([]);
   const [selectedTagList, setSelectedTagList] = useState([]);
   const [roomList, setRoomList] = useState([]);
-  const { changeUserNickname } = useUser();
   const { openChatting, closeChatting } = useChattingModal();
 
   const getImage = async () => {
@@ -75,14 +73,6 @@ const RoomList = ({ gameId }) => {
     );
   };
 
-  const generateSixDigits = () => {
-    // 닉네임에만 쓰일 숫자(userId와 관련 없음) 익명#84729384
-    // TODO: 지금은 숫자로 퉁치지만, 시간 나면 바로 형용사 + 명사 랜덤 매칭
-    // { noun: '너구리', image: '너구리 사진' }
-    // 라이브러리 npm 배포 가능
-    return Math.floor(100000 + Math.random() * 90000);
-  };
-
   const joinChatting = async (e) => {
     const selectedRoomId = e.target.closest('.room-container').dataset.roomId;
 
@@ -107,9 +97,6 @@ const RoomList = ({ gameId }) => {
     getImage();
     getRooms('');
     getTags();
-
-    // TODO: localStorage로 새로고침 후에도 닉네임 유지되도록 관리
-    changeUserNickname(`익명#${generateSixDigits()}`);
   }, []);
 
   useInterval(() => {


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
![image](https://user-images.githubusercontent.com/42052110/127784233-bf10d29b-bf16-40b2-a292-7e60837362f4.png)

## 🔥 구현 내용 요약
-  방 생성 후 방 목록 페이지 재입장 시 닉네임이 변경되는 문제 수정

## ☠ 트러블 슈팅
- 채팅 방이 만들어질 때 방 목록이 리렌더되는데, 리렌더 되면 닉네임이 새로 발급되기 때문에 생긴 문제였음