### PR TITLE
fix: 영어 텍스트가 길어져도 말풍선을 벗어나지 않도록 수정

### DIFF
--- a/front/src/components/SpeechBubble/SpeechBubble.scss
+++ b/front/src/components/SpeechBubble/SpeechBubble.scss
@@ -30,6 +30,7 @@
       max-width: 30rem;
       padding: 1.2rem 2rem;
       font-size: 1.3rem;
+      word-break: break-word;
       white-space: pre-wrap;
     }
 


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약
- 영어 텍스트가 길어져도 말풍선을 벗어나지 않도록 수정

## ☠ 트러블 슈팅
