### PR TITLE
chore: sonarCube 테스트 커버러지를 나타내기 위한 jacoco 추가

### DIFF
--- a/back/babble/build.gradle
+++ b/back/babble/build.gradle
@@ -1,9 +1,10 @@
 plugins {
-	id 'org.springframework.boot' version '2.5.2'
-	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-	id 'org.asciidoctor.jvm.convert' version '3.1.0'
-	id 'java'
-	id 'org.sonarqube' version '3.0'
+    id 'org.springframework.boot' version '2.5.2'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.asciidoctor.jvm.convert' version '3.1.0'
+    id 'java'
+    id 'org.sonarqube' version '3.0'
+    id 'jacoco'
 }
 
 group = 'gg.babble'
@@ -11,72 +12,85 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.webjars:webjars-locator-core'
-	implementation 'org.webjars:sockjs-client:1.0.2'
-	implementation 'org.webjars:stomp-websocket:2.3.3'
-	implementation 'org.webjars:bootstrap:3.3.7'
-	implementation 'org.webjars:jquery:3.1.1-1'
-	implementation 'org.flywaydb:flyway-core:7.12.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:webjars-locator-core'
+    implementation 'org.webjars:sockjs-client:1.0.2'
+    implementation 'org.webjars:stomp-websocket:2.3.3'
+    implementation 'org.webjars:bootstrap:3.3.7'
+    implementation 'org.webjars:jquery:3.1.1-1'
+    implementation 'org.flywaydb:flyway-core:7.12.0'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	testImplementation 'org.assertj:assertj-core:3.20.2'
-	testImplementation 'io.rest-assured:rest-assured:4.4.0'
-	testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
+    testImplementation 'io.rest-assured:rest-assured:4.4.0'
+    testImplementation 'io.projectreactor:reactor-test'
 }
 
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled true
+        csv.enabled true
+        xml.enabled true
+    }
+}
+test.finalizedBy jacocoTestReport
+
 test {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 asciidoctor.doFirst {
-	delete file('src/main/resources/static/docs')
+    delete file('src/main/resources/static/docs')
 }
 
 asciidoctor {
-	attributes 'snippets': snippetsDir
-	inputs.dir snippetsDir
-	dependsOn test
+    attributes 'snippets': snippetsDir
+    inputs.dir snippetsDir
+    dependsOn test
 }
 
 bootJar {
-	dependsOn asciidoctor
-	from ("${asciidoctor.outputDir}/html5") {
-		into 'static/docs'
-	}
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
 }
 
 task copyDocument(type: Copy) {
-	dependsOn bootJar
+    dependsOn bootJar
 
-	from file("build/docs/asciidoc/api-docs.html")
-	into file("src/main/resources/static/docs")
+    from file("build/docs/asciidoc/api-docs.html")
+    into file("src/main/resources/static/docs")
 }
 
 build {
-	dependsOn copyDocument
+    dependsOn copyDocument
 }


### PR DESCRIPTION
Closes #347 

## 😎 캡쳐본

![image](https://user-images.githubusercontent.com/43930419/128615897-5972f45d-8607-496c-91e5-57b17bdee9fc.png)

로컬상에서 테스트했을때 커버러지 표시되는것을 확인했습니다. `78.8%`

## 🔥 구현 내용 요약

- jacoco를 추가하여, 테스트 커버러지가 sonarcube에서 표시되도록 구현

## ☠ 트러블 슈팅

### 실패 케이스1
```java
plugins {
    ...
    id 'jacoco'
}

jacoco {
    toolVersion = "0.8.7"
}

jacocoTestReport {
    reports {
        html.enabled true
        csv.enabled true 
        xml.enabled true
    }
}
```

- jacoco 기본설정 추가
  - **실패(커버러지 0%가 지속되었다.)**

![image](https://user-images.githubusercontent.com/43930419/128615912-50ca1aff-0943-473f-af78-c18838990a6d.png)
- `jacoco/test.exec`가 있으나 적용이 되지않음.

### 실패 케이스2
- 서버 재시작 : https://community.sonarsource.com/t/sonarqube-code-coverage-is-0/38807
  - **실패**


### 성공 케이스
- 옵션추가 : https://tomgregory.com/how-to-measure-code-coverage-using-sonarqube-and-jacoco/

```java
jacocoTestReport {
    reports {
        html.enabled true
        csv.enabled true 
        xml.enabled true 
    }
}
test.finalizedBy jacocoTestReport
```

> we use finalizedBy to ensure that the test report is always generated after tests are run

- `test.finalizedBy jacocoTestReport` 을 넣어주었다.
  - **성공!**


![image](https://user-images.githubusercontent.com/43930419/128615919-aa3e4d5e-b88a-4ab1-b7c3-3e51d0553aae.png)

이전까지 생성되지 않았던, csv, xml 파일이 생성된것을 확인할 수 있다.

### 주의할점
- `./gradlew sonarqube` 이전에 반드시 `./gradlew test` 가 선행되어야함.
  - `./gradle build`가  `./gradlew test` 역할도 수행해주므로 yml 파일 수정은 불필요.
