### PR TITLE
chore: 워크플로우 동작 사이 의존성 부여

### DIFF
--- a/.github/workflows/back-main.yml
+++ b/.github/workflows/back-main.yml
@@ -10,26 +10,7 @@ on:
       - 'back/**'
 
 jobs:
-  sonarqube-build:
-    runs-on: deploy
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-
-    - name: gradlew 권한 변경
-      working-directory: ./back/babble
-      run: chmod +x gradlew
-
-    - name: 소나큐브 빌드 진행
-      working-directory: ./back/babble
-      run: ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}
-
-  build:
+  deploy-build:
     runs-on: deploy
 
     steps:
@@ -55,5 +36,22 @@ jobs:
     - name: SSH 명령을 통해 WAS 서버 접속 후 jar 파일 실행
       run: ssh was "/home/ubuntu/deploy/deploy.sh"
 
-#       run: ssh was "mv /home/ubuntu/babble-0.0.1-SNAPSHOT.jar /home/ubuntu/deploy; sudo docker build -t babble/was /home/ubuntu/deploy; sudo docker run -d -p 8080:8080 babble/was;"
-#     run: nohup java -jar -Dspring.profiles.active=prod ./build/libs/atdd-subway-fare-0.0.1-SNAPSHOT.jar 1> ./logs/error.log 2>&1 &
+  sonarqube-build:
+    runs-on: deploy
+    needs: deploy-build
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: gradlew 권한 변경
+      working-directory: ./back/babble
+      run: chmod +x gradlew
+
+    - name: 소나큐브 빌드 진행
+      working-directory: ./back/babble
+      run: ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}

--- a/.github/workflows/back-release.yml
+++ b/.github/workflows/back-release.yml
@@ -10,26 +10,7 @@ on:
       - 'back/**'
 
 jobs:
-  sonarqube-build:
-    runs-on: deploy
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-
-    - name: gradlew 권한 변경
-      working-directory: ./back/babble
-      run: chmod +x gradlew
-
-    - name: 소나큐브 빌드 진행
-      working-directory: ./back/babble
-      run: ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}
-
-  build:
+  deploy-build:
     runs-on: deploy
 
     steps:
@@ -55,5 +36,22 @@ jobs:
     - name: SSH 명령을 통해 테스트용 서버 접속 후 jar 파일 실행
       run: ssh test "cd was; /home/ubuntu/was/deploy.sh;"
 
-#       run: ssh was "mv /home/ubuntu/babble-0.0.1-SNAPSHOT.jar /home/ubuntu/deploy; sudo docker build -t babble/was /home/ubuntu/deploy; sudo docker run -d -p 8080:8080 babble/was;"
-#     run: nohup java -jar -Dspring.profiles.active=prod ./build/libs/atdd-subway-fare-0.0.1-SNAPSHOT.jar 1> ./logs/error.log 2>&1 &
+  sonarqube-build:
+    runs-on: deploy
+    needs: deploy-build
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: gradlew 권한 변경
+      working-directory: ./back/babble
+      run: chmod +x gradlew
+
+    - name: 소나큐브 빌드 진행
+      working-directory: ./back/babble
+      run: ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}


### PR DESCRIPTION
## 🔥 구현 내용 요약
배포 빌드와 소나큐브 빌드 사이 `needs` 키워드를 통해 의존성을 추가하여 배포 빌드가 무조건 우선시 되도록 설정했습니다.
만약 배포 빌드가 실패할 경우, 배포 빌드에 의존하는 소나큐브 빌드는 진행되지 않습니다.
