### PR TITLE
feat: 랜덤 아바타 기능 구현

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/domain/Game.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/Game.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 public class Game {
 
     private static final String DEFAULT_IMAGE = "https://static-cdn.jtvnw.net/ttv-static/404_boxart-1080x1436.jpg";
+    @Embedded
+    private final Rooms rooms = new Rooms();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,8 +29,6 @@ public class Game {
     private String name;
     @NotNull(message = "게임 이미지는 Null 일 수 없습니다.")
     private String image;
-    @Embedded
-    private final Rooms rooms = new Rooms();
 
     public Game(final String name) {
         this(null, name, DEFAULT_IMAGE);

--- a/back/babble/src/main/java/gg/babble/babble/domain/user/User.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/user/User.java
@@ -20,18 +20,22 @@ import lombok.NoArgsConstructor;
 @Entity
 public class User {
 
-    @NotNull(message = "아바타는 Null 이어서는 안됩니다.")
-    private final String avatar = "https://hyeon9mak.github.io/assets/images/9vatar.png";
-    // TODO: 기본 경로 프론트에게 받아오기
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private static final String AVATAR_FORMAT = "https://bucket-babble-front.s3.ap-northeast-2.amazonaws.com/img/users/profiles/profile%d.png";
+    private static final int NUMBER_OF_AVATAR = 70;
+
     @NotNull(message = "닉네임은 Null 이어서는 안됩니다.")
     private String nickname;
+
     @ManyToOne
     @JoinColumn(name = "room_id")
     private Room room;
 
+    @NotNull(message = "아바타는 Null 이어서는 안됩니다.")
+    private String avatar;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     private LocalDateTime joinedAt;
 
     public User(final String nickname) {
@@ -50,6 +54,12 @@ public class User {
         this.id = id;
         this.nickname = nickname;
         this.room = room;
+        this.avatar = avatarByNickname(nickname);
+    }
+
+    public static String avatarByNickname(final String nickname) {
+        long avatarIndex = ((long) nickname.hashCode() - Integer.MIN_VALUE) % NUMBER_OF_AVATAR;
+        return String.format(AVATAR_FORMAT, avatarIndex);
     }
 
     public void join(final Room room) {

--- a/back/babble/src/main/java/gg/babble/babble/util/UrlParser.java
+++ b/back/babble/src/main/java/gg/babble/babble/util/UrlParser.java
@@ -22,7 +22,7 @@ public enum UrlParser {
     }
 
     private static void urlParsingValidate(final String url) {
-        if(!PATH_MATCHER.match(ROOM_SUBSCRIBE_URL_PATTERN.urlPattern, url)){
+        if (!PATH_MATCHER.match(ROOM_SUBSCRIBE_URL_PATTERN.urlPattern, url)) {
             throw new BabbleIllegalStatementException("roomId를 파싱할 수 없는 url 입니다.");
         }
     }

--- a/back/babble/src/test/java/gg/babble/babble/controller/WebSocketChattingTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/controller/WebSocketChattingTest.java
@@ -52,7 +52,7 @@ public class WebSocketChattingTest extends ApplicationTest {
     @Test
     public void testUserUpdateEndpoint() throws InterruptedException, ExecutionException, TimeoutException {
         MessageResponse expectedMessageResponse = new MessageResponse(
-            new UserResponse(2L, "와일더", "https://hyeon9mak.github.io/assets/images/9vatar.png"),
+            new UserResponse(2L, "와일더", "https://bucket-babble-front.s3.ap-northeast-2.amazonaws.com/img/users/profiles/profile66.png"),
             "철권 붐은 온다.", "chat"
         );
 

--- a/back/babble/src/test/java/gg/babble/babble/domain/UserTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/UserTest.java
@@ -1,0 +1,21 @@
+package gg.babble.babble.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gg.babble.babble.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+    @DisplayName("같은 닉네임이면 같은 아바타가 나온다.")
+    @Test
+    void avatarByNickname() {
+        // when
+        User user1 = new User("루트");
+        User user2 = new User("루트");
+
+        // then
+        assertThat(user1.getAvatar()).isEqualTo(user2.getAvatar());
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/UserApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/UserApiDocumentTest.java
@@ -60,7 +60,7 @@ public class UserApiDocumentTest extends ApplicationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.nickname").value("fortune"))
             .andExpect(jsonPath("$.id").isNumber())
-            .andExpect(jsonPath("$.avatar").value("https://hyeon9mak.github.io/assets/images/9vatar.png"))
+            .andExpect(jsonPath("$.avatar").value("https://bucket-babble-front.s3.ap-northeast-2.amazonaws.com/img/users/profiles/profile57.png"))
 
             .andDo(document("create-user",
                 requestFields(fieldWithPath("nickname").description("닉네임")),

--- a/back/babble/src/test/java/gg/babble/babble/service/UserServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/UserServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class UserServiceTest extends ApplicationTest {
 
     private static final String FORTUNE = "fortune";
-    private static final String DEFAULT_URL = "https://hyeon9mak.github.io/assets/images/9vatar.png";
+    private static final String FORTUNE_AVATAR = "https://bucket-babble-front.s3.ap-northeast-2.amazonaws.com/img/users/profiles/profile57.png";
     @Autowired
     private UserService userService;
 
@@ -34,6 +34,6 @@ public class UserServiceTest extends ApplicationTest {
         // then
         assertThat(response.getId()).isNotNull();
         assertThat(response.getNickname()).isEqualTo(FORTUNE);
-        assertThat(response.getAvatar()).isEqualTo(DEFAULT_URL);
+        assertThat(response.getAvatar()).isEqualTo(FORTUNE_AVATAR);
     }
 }


### PR DESCRIPTION
Closes #307 #190

## 🔥 구현 내용 요약
유저 기본 아마타를 랜덤으로 생성하게 구현했다.

## ☠ 트러블 슈팅
String의 hashCode() 메소드를 이용해서 구현하려고 했으나 hashCode의 리턴 타입 int라 오버플로우로 음수가 나오는 경우가 발생했다.
int의 최소 값을 빼는 방법으로 이를 해결했다.

```java
long avatarIndex = ((long) nickname.hashCode() - Integer.MIN_VALUE) % NUMBER_OF_AVATAR;
```