### PR TITLE
fix: syntax error 수정

### DIFF
--- a/back/babble/src/main/resources/db/migration/V2__add_column_deleted.sql
+++ b/back/babble/src/main/resources/db/migration/V2__add_column_deleted.sql
@@ -1,3 +1,3 @@
 alter table game add deleted boolean not null;
 
-alter table room change is_deleted deleted;
+alter table room change is_deleted deleted boolean not null;


### PR DESCRIPTION
## 🔥 구현 내용 요약

## ☠ 트러블 슈팅

mariaDB는 컬럼명 수정 시 기존 타입까지 함께 입력해줘야된다.

<https://bskyvision.com/1026>