### PR TITLE
post api 201 상태코드 변경

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
@@ -49,9 +49,9 @@ public class GameController {
 
     @PostMapping
     public ResponseEntity<GameWithImageResponse> insertGame(@RequestBody final GameRequest request) {
-        GameWithImageResponse gameWithImageResponse = gameService.insertGame(request);
-        return ResponseEntity.created(URI.create(String.format("api/games/%s", gameWithImageResponse.getId())))
-            .body(gameWithImageResponse);
+        GameWithImageResponse response = gameService.insertGame(request);
+        return ResponseEntity.created(URI.create(String.format("api/games/%s", response.getId())))
+            .body(response);
     }
 
     @PutMapping(value = "/{gameId}")

--- a/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/GameController.java
@@ -5,6 +5,7 @@ import gg.babble.babble.dto.response.GameImageResponse;
 import gg.babble.babble.dto.response.GameWithImageResponse;
 import gg.babble.babble.dto.response.IndexPageGameResponse;
 import gg.babble.babble.service.GameService;
+import java.net.URI;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -48,7 +49,9 @@ public class GameController {
 
     @PostMapping
     public ResponseEntity<GameWithImageResponse> insertGame(@RequestBody final GameRequest request) {
-        return ResponseEntity.ok(gameService.insertGame(request));
+        GameWithImageResponse gameWithImageResponse = gameService.insertGame(request);
+        return ResponseEntity.created(URI.create(String.format("api/games/%s", gameWithImageResponse.getId())))
+            .body(gameWithImageResponse);
     }
 
     @PutMapping(value = "/{gameId}")

--- a/back/babble/src/main/java/gg/babble/babble/controller/RoomController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/RoomController.java
@@ -30,7 +30,7 @@ public class RoomController {
     @PostMapping
     public ResponseEntity<CreatedRoomResponse> createRoom(@Valid @RequestBody final RoomRequest request) {
         CreatedRoomResponse response = roomService.create(request);
-        return ResponseEntity.created(URI.create("api/rooms/" + response.getRoomId()))
+        return ResponseEntity.created(URI.create(String.format("api/rooms/%s", response.getRoomId())))
             .body(response);
     }
 
@@ -41,9 +41,9 @@ public class RoomController {
     }
 
     @GetMapping
-    public ResponseEntity<List<FoundRoomResponse>> readRoomByTags(@RequestParam Long gameId,
-                                                                  @RequestParam(defaultValue = "") List<Long> tagIds,
-                                                                  Pageable pageable) {
+    public ResponseEntity<List<FoundRoomResponse>> readRoomByTags(@RequestParam final Long gameId,
+                                                                  @RequestParam(defaultValue = "") final List<Long> tagIds,
+                                                                  final Pageable pageable) {
         return ResponseEntity.ok(roomService.findGamesByGameIdAndTagIds(gameId, tagIds, pageable));
     }
 }

--- a/back/babble/src/main/resources/static/docs/api-docs.html
+++ b/back/babble/src/main/resources/static/docs/api-docs.html
@@ -833,11 +833,11 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 454
+Content-Length: 457
 
 {
   "roomId" : 1,
-  "createdDate" : "2021-08-09T21:45:26.261",
+  "createdDate" : "2021-08-10T02:10:22.017077",
   "game" : {
     "id" : 1,
     "name" : "League Of Legends"
@@ -1001,11 +1001,11 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Location: api/rooms/21
 Content-Type: application/json
-Content-Length: 303
+Content-Length: 306
 
 {
   "roomId" : 21,
-  "createdDate" : "2021-08-09T21:45:30.295",
+  "createdDate" : "2021-08-10T02:10:35.331582",
   "game" : {
     "id" : 1,
     "name" : "League Of Legends"
@@ -1258,7 +1258,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-08-09 21:43:37 +0900
+Last updated 2021-08-09 22:59:56 +0900
 </div>
 </div>
 </body>

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
@@ -139,7 +139,7 @@ public class GameApiDocumentTest extends ApplicationTest {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(objectMapper.writeValueAsString(body)).characterEncoding("utf-8"))
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isOk())
+            .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").isNumber())
             .andExpect(jsonPath("$.name").value(gameName))
             .andExpect(jsonPath("$.thumbnail").value(thumbnail))


### PR DESCRIPTION
Closes #390 

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약
- https://www.notion.so/POST-201-vs-200-fd061db126ff46a29aa2ad175351ae42

User Created도 201로 반환할까 하다가, 현재 UserId를 사용하는 부분이 전혀 없어서 일단 200으로 현상유지 해놓았습니다.
- https://github.com/woowacourse-teams/2021-babble/blob/58dfb31d2f2293f1e75cd07ecce7bb6d8e268e2b/back/babble/src/main/java/gg/babble/babble/controller/UserController.java#L23

## ☠ 트러블 슈팅
- 전자레인지 돌리면서 이슈목록 슥보다가, 별거아니길래 손댓다가 테스트만 30분넘게 쳐다봤습니다. -_-
