### PR TITLE
관리자 필터 기능 구현 (#410)

### DIFF
--- a/.github/workflows/back-main.yml
+++ b/.github/workflows/back-main.yml
@@ -15,33 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        java-version: '8'
-        distribution: 'adopt'
-
-    - name: gradlew 권한 변경
-      working-directory: ./back/babble
-      run: chmod +x gradlew
-
-    - name: 빌드 진행
-      working-directory: ./back/babble
-      run: ./gradlew build
-
-    - name: SCP 명령을 이용해 WAS 서버로 jar 파일 전송
-      working-directory: ./back/babble
-      run: scp ./build/libs/babble-0.0.1-SNAPSHOT.jar was:/home/ubuntu
-
-    - name: SSH 명령을 통해 WAS 서버 접속 후 jar 파일 실행
-      run: ssh was "/home/ubuntu/deploy/deploy.sh"
-
-  sonarqube-build:
-    runs-on: deploy
-    needs: deploy-build
-
-    steps:
-    - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
@@ -52,6 +25,18 @@ jobs:
       working-directory: ./back/babble
       run: chmod +x gradlew
 
+    - name: 빌드 진행
+      working-directory: ./back/babble
+      run: ./gradlew build
+
     - name: 소나큐브 빌드 진행
       working-directory: ./back/babble
       run: ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}
+
+    - name: SCP 명령을 이용해 WAS 서버로 jar 파일 전송
+      working-directory: ./back/babble
+      run: scp ./build/libs/babble-0.0.1-SNAPSHOT.jar was:/home/ubuntu
+
+    - name: SSH 명령을 통해 WAS 서버 접속 후 jar 파일 실행
+      run: ssh was "/home/ubuntu/deploy/deploy.sh"
+      

--- a/back/babble/src/docs/asciidoc/api-docs.adoc
+++ b/back/babble/src/docs/asciidoc/api-docs.adoc
@@ -98,6 +98,21 @@ include::{snippets}/find-game-image-by-id/http-response.adoc[]
 [cols="^,^,^",options="headers"]
 include::{snippets}/read-game-image/response-fields.adoc[]
 
+=== 게임 등록 API
+
+> Accessible only from allowed ip.
+
+==== HTTP Request
+
+include::{snippets}/create-game/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/create-game/http-response.adoc[]
+[width="40%"]
+[cols="^,^,^",options="headers"]
+include::{snippets}/insert-game/response-fields.adoc[]
+
 == 방
 
 === 방 조회 API
@@ -143,6 +158,47 @@ include::{snippets}/tags-get-test/http-response.adoc[]
 [width="40%"]
 [cols="^,^,^",options="headers"]
 include::{snippets}/tags-get/response-fields.adoc[]
+
+== 관리자
+
+> Accessible only from allowed ip.
+
+=== 관리자 전체 조회 API
+
+==== HTTP Request
+
+include::{snippets}/find-all-administrator/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/find-all-administrator/http-response.adoc[]
+[width="40%"]
+[cols="^,^,^",options="headers"]
+include::{snippets}/read-administrators/response-fields.adoc[]
+
+=== 관리자 등록 API
+
+==== HTTP Request
+
+include::{snippets}/create-administrator//http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/create-administrator/http-response.adoc[]
+[width="40%"]
+[cols="^,^,^",options="headers"]
+include::{snippets}/insert-administrator/response-fields.adoc[]
+
+=== 관리자 삭제 API
+
+==== HTTP Request
+
+include::{snippets}/delete-administrators/http-request.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/delete-administrators/http-response.adoc[]
+
 
 == WebSocket
 

--- a/back/babble/src/main/java/gg/babble/babble/config/AdminAccessInterceptor.java
+++ b/back/babble/src/main/java/gg/babble/babble/config/AdminAccessInterceptor.java
@@ -1,0 +1,27 @@
+package gg.babble.babble.config;
+
+import gg.babble.babble.service.auth.AdministratorService;
+import gg.babble.babble.util.UrlParser;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AdminAccessInterceptor implements HandlerInterceptor {
+
+    private final AdministratorService administratorService;
+
+    public AdminAccessInterceptor(final AdministratorService administratorService) {
+        this.administratorService = administratorService;
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+        String requestUrl = request.getRequestURI();
+        if ("OPTIONS".equals(request.getMethod()) || (!UrlParser.isAuthenticationUrl(requestUrl) && "GET".equals(request.getMethod()))) {
+            return true;
+        }
+        String clientIp = request.getRemoteAddr();
+        administratorService.validateIp(clientIp);
+        return true;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/config/StompHandler.java
+++ b/back/babble/src/main/java/gg/babble/babble/config/StompHandler.java
@@ -1,6 +1,6 @@
 package gg.babble.babble.config;
 
-import gg.babble.babble.service.SubscribeAuthService;
+import gg.babble.babble.service.auth.SubscribeAuthService;
 import java.util.Objects;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;

--- a/back/babble/src/main/java/gg/babble/babble/config/WebConfig.java
+++ b/back/babble/src/main/java/gg/babble/babble/config/WebConfig.java
@@ -1,11 +1,25 @@
 package gg.babble.babble.config;
 
+import gg.babble.babble.service.auth.AdministratorService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AdministratorService administratorService;
+
+    public WebConfig(final AdministratorService administratorService) {
+        this.administratorService = administratorService;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminAccessInterceptor(administratorService))
+            .addPathPatterns("/api/games/**", "/api/tags/**", "/api/sliders/**", "/api/admins/**");
+    }
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {

--- a/back/babble/src/main/java/gg/babble/babble/controller/auth/AdministratorController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/auth/AdministratorController.java
@@ -1,0 +1,44 @@
+package gg.babble.babble.controller.auth;
+
+import gg.babble.babble.dto.request.AdministratorRequest;
+import gg.babble.babble.dto.response.AdministratorResponse;
+import gg.babble.babble.service.auth.AdministratorService;
+import java.net.URI;
+import java.util.List;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/admins")
+@RestController
+public class AdministratorController {
+
+    private final AdministratorService administratorService;
+
+    public AdministratorController(final AdministratorService administratorService) {
+        this.administratorService = administratorService;
+    }
+
+    @GetMapping
+    private ResponseEntity<List<AdministratorResponse>> findAll() {
+        return ResponseEntity.ok(administratorService.findAll());
+    }
+
+    @PostMapping
+    private ResponseEntity<AdministratorResponse> insert(@Valid @RequestBody AdministratorRequest request) {
+        AdministratorResponse response = administratorService.insert(request);
+        return ResponseEntity.created(URI.create("/api/admins/" + response.getId())).body(response);
+    }
+
+    @DeleteMapping("/{id}")
+    private ResponseEntity<Void> deleteAdministrator(@PathVariable final Long id) {
+        administratorService.deleteAdministrator(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/admin/Administrator.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/admin/Administrator.java
@@ -1,0 +1,34 @@
+package gg.babble.babble.domain.admin;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Administrator {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Embedded
+    private Ip ip;
+
+    @NotNull
+    private String name;
+
+    public Administrator(final String ip, final String name) {
+        this(null, new Ip(ip), name);
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/admin/Ip.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/admin/Ip.java
@@ -1,0 +1,31 @@
+package gg.babble.babble.domain.admin;
+
+import gg.babble.babble.exception.BabbleIllegalArgumentException;
+import java.util.regex.Pattern;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Embeddable
+public class Ip {
+
+    public static final String IP_REGEXP = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$";
+    private static final Pattern IP_PATTERN = Pattern.compile(IP_REGEXP);
+
+    @Column(name = "ip", unique = true)
+    private String value;
+
+    public Ip(final String value) {
+        validateToConstruct(value);
+        this.value = value;
+    }
+
+    private void validateToConstruct(final String value) {
+        if (!IP_PATTERN.matcher(value).matches()) {
+            throw new BabbleIllegalArgumentException(String.format("%s는 IP 형식에 맞지 않습니다.", value));
+        }
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/repository/AdministratorRepository.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/repository/AdministratorRepository.java
@@ -1,0 +1,10 @@
+package gg.babble.babble.domain.repository;
+
+import gg.babble.babble.domain.admin.Administrator;
+import gg.babble.babble.domain.admin.Ip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdministratorRepository extends JpaRepository<Administrator, Long> {
+
+    boolean existsAdministratorByIp(final Ip ip);
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/request/AdministratorRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/request/AdministratorRequest.java
@@ -1,0 +1,21 @@
+package gg.babble.babble.dto.request;
+
+import gg.babble.babble.domain.admin.Ip;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdministratorRequest {
+
+    @NotNull
+    @Pattern(regexp = Ip.IP_REGEXP)
+    private String ip;
+
+    @NotNull
+    private String name;
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/response/AdministratorResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/response/AdministratorResponse.java
@@ -1,0 +1,20 @@
+package gg.babble.babble.dto.response;
+
+import gg.babble.babble.domain.admin.Administrator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdministratorResponse {
+
+    private Long id;
+    private String ip;
+    private String name;
+
+    public static AdministratorResponse from(final Administrator administrator) {
+        return new AdministratorResponse(administrator.getId(), administrator.getIp().getValue(), administrator.getName());
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/exception/BabbleAuthenticationException.java
+++ b/back/babble/src/main/java/gg/babble/babble/exception/BabbleAuthenticationException.java
@@ -1,0 +1,15 @@
+package gg.babble.babble.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BabbleAuthenticationException extends BabbleException {
+
+    public BabbleAuthenticationException(final String message) {
+        super(message);
+    }
+
+    @Override
+    public HttpStatus status() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/service/auth/AdministratorService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/auth/AdministratorService.java
@@ -1,0 +1,52 @@
+package gg.babble.babble.service.auth;
+
+import gg.babble.babble.domain.admin.Administrator;
+import gg.babble.babble.domain.admin.Ip;
+import gg.babble.babble.domain.repository.AdministratorRepository;
+import gg.babble.babble.dto.request.AdministratorRequest;
+import gg.babble.babble.dto.response.AdministratorResponse;
+import gg.babble.babble.exception.BabbleAuthenticationException;
+import gg.babble.babble.exception.BabbleNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class AdministratorService {
+
+    private final AdministratorRepository administratorRepository;
+
+    public AdministratorService(final AdministratorRepository administratorRepository) {
+        this.administratorRepository = administratorRepository;
+    }
+
+    public void validateIp(final String ip) {
+        if (!administratorRepository.existsAdministratorByIp(new Ip(ip))) {
+            throw new BabbleAuthenticationException(String.format("허용되지 않는 Ip입니다. (현재 Ip: %s)", ip));
+        }
+    }
+
+    @Transactional
+    public void deleteAdministrator(final Long id) {
+        Administrator administrator = findById(id);
+        administratorRepository.delete(administrator);
+    }
+
+    private Administrator findById(final Long id) {
+        return administratorRepository.findById(id)
+            .orElseThrow(() -> new BabbleNotFoundException(String.format("존재하지 않는 관리자 Id(%d) 입니다.", id)));
+    }
+
+    public List<AdministratorResponse> findAll() {
+        return administratorRepository.findAll()
+            .stream()
+            .map(AdministratorResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    public AdministratorResponse insert(final AdministratorRequest request) {
+        return AdministratorResponse.from(administratorRepository.save(new Administrator(request.getIp(), request.getName())));
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/service/auth/SubscribeAuthService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/auth/SubscribeAuthService.java
@@ -1,6 +1,7 @@
-package gg.babble.babble.service;
+package gg.babble.babble.service.auth;
 
 import gg.babble.babble.exception.BabbleIllegalStatementException;
+import gg.babble.babble.service.RoomService;
 import gg.babble.babble.util.UrlParser;
 import org.springframework.stereotype.Service;
 

--- a/back/babble/src/main/java/gg/babble/babble/util/UrlParser.java
+++ b/back/babble/src/main/java/gg/babble/babble/util/UrlParser.java
@@ -5,7 +5,8 @@ import java.util.Map;
 import org.springframework.util.AntPathMatcher;
 
 public enum UrlParser {
-    ROOM_SUBSCRIBE_URL_PATTERN("/topic/rooms/{roomId}/*");
+    ROOM_SUBSCRIBE_URL_PATTERN("/topic/rooms/{roomId}/*"),
+    AUTHENTICATION_URL_PATTERN("/api/admins/**");
 
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
@@ -26,4 +27,9 @@ public enum UrlParser {
             throw new BabbleIllegalStatementException(String.format("%s은 roomId를 파싱할 수 없는 url 입니다.", url));
         }
     }
+
+    public static boolean isAuthenticationUrl(final String url) {
+        return PATH_MATCHER.match(AUTHENTICATION_URL_PATTERN.urlPattern, url);
+    }
+
 }

--- a/back/babble/src/main/resources/db/migration/V3__add_table_administrator.sql
+++ b/back/babble/src/main/resources/db/migration/V3__add_table_administrator.sql
@@ -1,0 +1,7 @@
+create table administrator
+(
+    id    bigint auto_increment,
+    ip varchar(255) not null unique,
+    name  varchar(255) not null,
+    primary key (id)
+);

--- a/back/babble/src/main/resources/static/docs/api-docs.html
+++ b/back/babble/src/main/resources/static/docs/api-docs.html
@@ -456,6 +456,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_게임_단일_조회_api">3.2. 게임 단일 조회 API</a></li>
 <li><a href="#_게임_이미지_리스트_조회_api">3.3. 게임 이미지 리스트 조회 API</a></li>
 <li><a href="#_단일_게임_이미지_조회_api">3.4. 단일 게임 이미지 조회 API</a></li>
+<li><a href="#_게임_등록_api">3.5. 게임 등록 API</a></li>
 </ul>
 </li>
 <li><a href="#_방">4. 방</a>
@@ -469,11 +470,18 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_태그_전체_수신_api">5.1. 태그 전체 수신 API</a></li>
 </ul>
 </li>
-<li><a href="#_websocket">6. WebSocket</a>
+<li><a href="#_관리자">6. 관리자</a>
 <ul class="sectlevel2">
-<li><a href="#_방_입장_api">6.1. 방 입장 API</a></li>
-<li><a href="#_방_입장_정보_업데이트_api">6.2. 방 입장 정보 업데이트 API</a></li>
-<li><a href="#_채팅_전송_api">6.3. 채팅 전송 API</a></li>
+<li><a href="#_관리자_전체_조회_api">6.1. 관리자 전체 조회 API</a></li>
+<li><a href="#_관리자_등록_api">6.2. 관리자 등록 API</a></li>
+<li><a href="#_관리자_삭제_api">6.3. 관리자 삭제 API</a></li>
+</ul>
+</li>
+<li><a href="#_websocket">7. WebSocket</a>
+<ul class="sectlevel2">
+<li><a href="#_방_입장_api">7.1. 방 입장 API</a></li>
+<li><a href="#_방_입장_정보_업데이트_api">7.2. 방 입장 정보 업데이트 API</a></li>
+<li><a href="#_채팅_전송_api">7.3. 채팅 전송 API</a></li>
 </ul>
 </li>
 </ul>
@@ -807,6 +815,84 @@ Content-Length: 109
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_게임_등록_api">3.5. 게임 등록 API</h3>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Accessible only from allowed ip.</p>
+</div>
+</blockquote>
+</div>
+<div class="sect3">
+<h4 id="_http_request_5">3.5.1. HTTP Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/games HTTP/1.1
+Content-Type: application/json;charset=utf-8
+Accept: application/json
+Content-Length: 63
+Host: localhost:8080
+
+{
+  "thumbnail" : "image.png",
+  "name" : "League Of Legends"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_5">3.5.2. HTTP Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Location: api/games/4
+Content-Type: application/json
+Content-Length: 75
+
+{
+  "id" : 4,
+  "name" : "League Of Legends",
+  "thumbnail" : "image.png"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Path</th>
+<th class="tableblock halign-center valign-top">Type</th>
+<th class="tableblock halign-center valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>thumbnail</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">게임 썸네일 URL</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -815,7 +901,7 @@ Content-Length: 109
 <div class="sect2">
 <h3 id="_방_조회_api">4.1. 방 조회 API</h3>
 <div class="sect3">
-<h4 id="_http_request_5">4.1.1. HTTP Request</h4>
+<h4 id="_http_request_6">4.1.1. HTTP Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/rooms/1 HTTP/1.1
@@ -825,7 +911,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_5">4.1.2. HTTP Response</h4>
+<h4 id="_http_response_6">4.1.2. HTTP Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
@@ -833,11 +919,11 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
-Content-Length: 457
+Content-Length: 454
 
 {
   "roomId" : 1,
-  "createdDate" : "2021-08-10T02:10:22.017077",
+  "createdDate" : "2021-08-11T15:08:12.997",
   "game" : {
     "id" : 1,
     "name" : "League Of Legends"
@@ -937,7 +1023,7 @@ Content-Length: 457
 <div class="sect2">
 <h3 id="_방_생성_api">4.2. 방 생성 API</h3>
 <div class="sect3">
-<h4 id="_http_request_6">4.2.1. HTTP Request</h4>
+<h4 id="_http_request_7">4.2.1. HTTP Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/rooms HTTP/1.1
@@ -992,7 +1078,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_6">4.2.2. HTTP Response</h4>
+<h4 id="_http_response_7">4.2.2. HTTP Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
@@ -1001,11 +1087,11 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Location: api/rooms/21
 Content-Type: application/json
-Content-Length: 306
+Content-Length: 303
 
 {
   "roomId" : 21,
-  "createdDate" : "2021-08-10T02:10:35.331582",
+  "createdDate" : "2021-08-11T15:08:16.513",
   "game" : {
     "id" : 1,
     "name" : "League Of Legends"
@@ -1085,7 +1171,7 @@ Content-Length: 306
 <div class="sect2">
 <h3 id="_태그_전체_수신_api">5.1. 태그 전체 수신 API</h3>
 <div class="sect3">
-<h4 id="_http_request_7">5.1.1. HTTP Request</h4>
+<h4 id="_http_request_8">5.1.1. HTTP Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/tags HTTP/1.1
@@ -1095,7 +1181,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_7">5.1.2. HTTP Response</h4>
+<h4 id="_http_response_8">5.1.2. HTTP Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
@@ -1148,12 +1234,178 @@ Content-Length: 120
 </div>
 </div>
 <div class="sect1">
-<h2 id="_websocket">6. WebSocket</h2>
+<h2 id="_관리자">6. 관리자</h2>
+<div class="sectionbody">
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Accessible only from allowed ip.</p>
+</div>
+</blockquote>
+</div>
+<div class="sect2">
+<h3 id="_관리자_전체_조회_api">6.1. 관리자 전체 조회 API</h3>
+<div class="sect3">
+<h4 id="_http_request_9">6.1.1. HTTP Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/admins HTTP/1.1
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_9">6.1.2. HTTP Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 64
+
+[ {
+  "id" : 1,
+  "ip" : "127.0.0.1",
+  "name" : "localhost"
+} ]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Path</th>
+<th class="tableblock halign-center valign-top">Type</th>
+<th class="tableblock halign-center valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>[].id</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">관리자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>[].ip</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">관리자 IP 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>[].name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">관리자 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_등록_api">6.2. 관리자 등록 API</h3>
+<div class="sect3">
+<h4 id="_http_request_10">6.2.1. HTTP Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/admins HTTP/1.1
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_10">6.2.2. HTTP Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 130
+
+[ {
+  "id" : 1,
+  "ip" : "127.0.0.1",
+  "name" : "localhost"
+}, {
+  "id" : 2,
+  "ip" : "111.111.11.11",
+  "name" : "포츈집"
+} ]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top">Path</th>
+<th class="tableblock halign-center valign-top">Type</th>
+<th class="tableblock halign-center valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">관리자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>ip</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">관리자 IP 주소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-center valign-top"><p class="tableblock">관리자 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_관리자_삭제_api">6.3. 관리자 삭제 API</h3>
+<div class="sect3">
+<h4 id="_http_request_11">6.3.1. HTTP Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /api/admins/1 HTTP/1.1
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_http_response_11">6.3.2. HTTP Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 204 No Content
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_websocket">7. WebSocket</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_방_입장_api">6.1. 방 입장 API</h3>
+<h3 id="_방_입장_api">7.1. 방 입장 API</h3>
 <div class="sect3">
-<h4 id="_http_request_8">6.1.1. HTTP Request</h4>
+<h4 id="_http_request_12">7.1.1. HTTP Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /connection HTTP/1.1</code></pre>
@@ -1161,7 +1413,7 @@ Content-Length: 120
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_8">6.1.2. HTTP Response</h4>
+<h4 id="_http_response_12">7.1.2. HTTP Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK</code></pre>
@@ -1170,9 +1422,9 @@ Content-Length: 120
 </div>
 </div>
 <div class="sect2">
-<h3 id="_방_입장_정보_업데이트_api">6.2. 방 입장 정보 업데이트 API</h3>
+<h3 id="_방_입장_정보_업데이트_api">7.2. 방 입장 정보 업데이트 API</h3>
 <div class="sect3">
-<h4 id="_websocket_send">6.2.1. WebSocket Send</h4>
+<h4 id="_websocket_send">7.2.1. WebSocket Send</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">SEND /ws/rooms/1/users
@@ -1186,7 +1438,7 @@ Content-Type: application/json
 </div>
 </div>
 <div class="sect3">
-<h4 id="_websocket_subscribe">6.2.2. WebSocket Subscribe</h4>
+<h4 id="_websocket_subscribe">7.2.2. WebSocket Subscribe</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">SUBSCRIBE /topic/rooms/1/users
@@ -1216,9 +1468,9 @@ Content-Type: application/json
 </div>
 </div>
 <div class="sect2">
-<h3 id="_채팅_전송_api">6.3. 채팅 전송 API</h3>
+<h3 id="_채팅_전송_api">7.3. 채팅 전송 API</h3>
 <div class="sect3">
-<h4 id="_websocket_send_2">6.3.1. WebSocket Send</h4>
+<h4 id="_websocket_send_2">7.3.1. WebSocket Send</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">/ws/rooms/1/chat
@@ -1233,7 +1485,7 @@ Content-Type: application/json
 </div>
 </div>
 <div class="sect3">
-<h4 id="_websocket_subscribe_2">6.3.2. WebSocket Subscribe</h4>
+<h4 id="_websocket_subscribe_2">7.3.2. WebSocket Subscribe</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">SUBSCRIBE /topic/rooms/1/chat
@@ -1258,7 +1510,7 @@ Content-Type: application/json
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-08-09 22:59:56 +0900
+Last updated 2021-08-11 14:40:48 +0900
 </div>
 </div>
 </body>

--- a/back/babble/src/test/java/gg/babble/babble/ApplicationWebSocketTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/ApplicationWebSocketTest.java
@@ -17,17 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ApplicationTest {
+public class ApplicationWebSocketTest {
 
     @LocalServerPort
     protected int port;
 
-    @Autowired
-    protected AdministratorRepository administratorRepository;
-
     @BeforeEach
     protected void setUp() {
         RestAssured.port = port;
-        administratorRepository.save(new Administrator("127.0.0.1", "localhost"));
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/acceptance/AuthTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/acceptance/AuthTest.java
@@ -1,33 +1,24 @@
-package gg.babble.babble;
+package gg.babble.babble.acceptance;
 
-import gg.babble.babble.domain.admin.Administrator;
-import gg.babble.babble.domain.repository.AdministratorRepository;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
-@Transactional
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ApplicationTest {
+public class AuthTest {
 
     @LocalServerPort
     protected int port;
 
-    @Autowired
-    protected AdministratorRepository administratorRepository;
-
     @BeforeEach
     protected void setUp() {
         RestAssured.port = port;
-        administratorRepository.save(new Administrator("127.0.0.1", "localhost"));
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/acceptance/GameAcceptanceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/acceptance/GameAcceptanceTest.java
@@ -1,0 +1,58 @@
+package gg.babble.babble.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gg.babble.babble.domain.admin.Administrator;
+import gg.babble.babble.domain.repository.AdministratorRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class GameAcceptanceTest extends AuthTest {
+
+    @Autowired
+    private AdministratorRepository administratorRepository;
+
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        RestAssured.port = port;
+    }
+
+    @DisplayName("등록되어 있는 IP의 경우 게임 생성을 할 수 있다.")
+    @Test
+    void postGameWithValidIp() {
+        administratorRepository.save(new Administrator("127.0.0.1", "localhost"));
+        ExtractableResponse<Response> response = 게임이_등록_됨("Maple Story", "abc");
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    private ExtractableResponse<Response> 게임이_등록_됨(final String name, final String thumbnail) {
+        Map<String, String> body = new HashMap<>();
+        body.put("name", name);
+        body.put("thumbnail", thumbnail);
+
+        return RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(body)
+            .when().post("/api/games")
+            .then().extract();
+    }
+
+    @DisplayName("등록되어 있지않는 IP의 경우 게임을 생성할 수 없다.")
+    @Test
+    void postGameWithInvalidIp() {
+        // when
+        ExtractableResponse<Response> response = 게임이_등록_됨("Maple Story", "abc");
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/controller/WebSocketChattingTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/controller/WebSocketChattingTest.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.ApplicationWebSocketTest;
 import gg.babble.babble.dto.request.MessageRequest;
 import gg.babble.babble.dto.request.UserJoinRequest;
 import gg.babble.babble.dto.response.MessageResponse;
@@ -29,7 +30,7 @@ import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
-public class WebSocketChattingTest extends ApplicationTest {
+public class WebSocketChattingTest extends ApplicationWebSocketTest {
 
     private static final String SUBSCRIBE_ROOM_UPDATE_BROAD_ENDPOINT = "/topic/rooms/1/users";
     private static final String SEND_ROOM_UPDATE_ENDPOINT = "/ws/rooms/1/users";

--- a/back/babble/src/test/java/gg/babble/babble/controller/WebSocketRoomUpdateTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/controller/WebSocketRoomUpdateTest.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.ApplicationWebSocketTest;
 import gg.babble.babble.domain.repository.UserRepository;
 import gg.babble.babble.domain.user.Nickname;
 import gg.babble.babble.domain.user.User;
@@ -33,7 +34,7 @@ import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
-public class WebSocketRoomUpdateTest extends ApplicationTest {
+public class WebSocketRoomUpdateTest extends ApplicationWebSocketTest {
 
     // TODO : 데이터로더에 비 의존적으로 리팩토링
 //    private static final int FIRST_DATA_INDEX = 0;

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/AdministratorApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/AdministratorApiDocumentTest.java
@@ -1,0 +1,138 @@
+package gg.babble.babble.restdocs;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.domain.admin.Administrator;
+import gg.babble.babble.domain.repository.AdministratorRepository;
+import gg.babble.babble.dto.response.AdministratorResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+public class AdministratorApiDocumentTest extends ApplicationTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(documentationConfiguration(restDocumentation))
+            .alwaysDo(document("{method-name}", preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+            .build();
+    }
+
+    @DisplayName("관리자 전체 조회한다.")
+    @Test
+    void findAllAdministrator() throws Exception {
+        관리자_전체_조회()
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.[0].id").isNumber())
+            .andExpect(jsonPath("$.[0].ip").value("127.0.0.1"))
+            .andExpect(jsonPath("$.[0].name").value("localhost"))
+
+            .andDo(document("read-administrators",
+                responseFields(
+                    fieldWithPath("[].id").description("관리자 ID"),
+                    fieldWithPath("[].ip").description("관리자 IP 주소"),
+                    fieldWithPath("[].name").description("관리자 이름")
+                )
+            ));
+    }
+
+    private ResultActions 관리자_전체_조회() throws Exception {
+        return mockMvc.perform(get("/api/admins")
+            .accept(MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @DisplayName("관리자 IP를 추가한다.")
+    @Test
+    void createAdministrator() throws Exception {
+        // given
+        String ip = "111.111.11.11";
+        String name = "포츈집";
+
+        // when
+        Map<String, Object> body = new HashMap<>();
+        body.put("ip", ip);
+        body.put("name", name);
+
+        // then
+        관리자_IP_추가_됨(body)
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").isNumber())
+            .andExpect(jsonPath("$.ip").value(ip))
+            .andExpect(jsonPath("$.name").value(name))
+
+            .andDo(document("insert-administrator",
+                requestFields(
+                    fieldWithPath("ip").description("관리자 IP 주소"),
+                    fieldWithPath("name").description("관리자 이름")
+                ),
+                responseFields(
+                    fieldWithPath("id").description("관리자 ID"),
+                    fieldWithPath("ip").description("관리자 IP 주소"),
+                    fieldWithPath("name").description("관리자 이름")
+                )
+            ));
+
+        관리자_전체_조회()
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)));
+    }
+
+    private ResultActions 관리자_IP_추가_됨(final Map<String, Object> body) throws Exception {
+        return mockMvc.perform(post("/api/admins")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(body)).characterEncoding("utf-8"));
+    }
+
+    @DisplayName("관리자 IP를 삭제한다.")
+    @Test
+    void deleteAdministrator() throws Exception {
+        String response = 관리자_전체_조회().andReturn().getResponse().getContentAsString();
+        Long idToDelete = objectMapper.readValue(
+            response, new TypeReference<List<AdministratorResponse>>() {
+            }).get(0).getId();
+
+        mockMvc.perform(delete("/api/admins/" + idToDelete)
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent())
+            .andDo(document("delete-administrators"));
+
+        관리자_전체_조회().andExpect(status().isUnauthorized());
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/GameApiDocumentTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.domain.admin.Administrator;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -126,7 +127,7 @@ public class GameApiDocumentTest extends ApplicationTest {
 
     @DisplayName("게임을 추가한다.")
     @Test
-    void insertGame() throws Exception {
+    void createGame() throws Exception {
         String gameName = "League Of Legends";
         String thumbnail = "image.png";
 

--- a/back/babble/src/test/java/gg/babble/babble/service/SubscribeAuthServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/SubscribeAuthServiceTest.java
@@ -15,6 +15,7 @@ import gg.babble.babble.domain.tag.Tag;
 import gg.babble.babble.domain.user.Nickname;
 import gg.babble.babble.domain.user.User;
 import gg.babble.babble.exception.BabbleIllegalStatementException;
+import gg.babble.babble.service.auth.SubscribeAuthService;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
* feat: 관리자 기능 API IP 필터링 구현

* test: 인증된 IP로 게임 등록 TC 추가

* feat: 관리자 ip 전체 조회 및 삭제 구현

* feat: 관리자 IP 전체 조회는 허가된 IP만 가능하도록 구현

* refactor: CommandLineRunner 없이 테스트하도록 수정

* feat: 관리자 Ip 추가 기능 구현

* docs: 추가 구현 사항 REST docs 반영

* chore: main 브랜치에도 소나큐브가 적용되도록 수정

* feat: 관리자 Ip Unique 속성 추가

웹 소켓 테스트의 경우 IP 중복 등록하는 이슈가 발견되어 상위 클래스를 분리함

* docs: 변경 사항 Rest docs 반영

Closes #

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약

## ☠ 트러블 슈팅
