### PR TITLE
fix: 스크롤 버그 수정 및 배너 이미지 적용

### DIFF
--- a/front/src/pages/GameList/GameList.js
+++ b/front/src/pages/GameList/GameList.js
@@ -19,23 +19,18 @@ const GameList = () => {
   const dummyImage = [
     {
       id: 0,
-      info: 'Teamfight Tactics',
-      src: 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/c2d19d4a-860f-4736-aaee-9671677c1bee/ddd8djc-68b444e6-738d-4428-822c-aac14e42c134.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcL2MyZDE5ZDRhLTg2MGYtNDczNi1hYWVlLTk2NzE2NzdjMWJlZVwvZGRkOGRqYy02OGI0NDRlNi03MzhkLTQ0MjgtODIyYy1hYWMxNGU0MmMxMzQuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.o-JsRdvyVURnwfQIS1C0b20UgfotvKZ3I6HR56_gDOY',
+      info: 'Kartrider Rush Plus',
+      src: 'https://babble.gg/img/banners/kartrider.png',
     },
     {
       id: 1,
-      info: 'Unrailed',
-      src: 'https://static3.srcdn.com/wordpress/wp-content/uploads/2020/09/Unrailed-Review-Logo.jpg',
+      info: 'APEX LEGENDS',
+      src: 'https://babble.gg/img/banners/apexlegends.png',
     },
     {
       id: 2,
-      info: 'Escape From Tarkov',
-      src: 'https://www.mrpcgamer.com/wp-content/uploads/2020/11/EFT-1.jpg',
-    },
-    {
-      id: 3,
-      info: 'Pokemon Unite',
-      src: 'https://www.videogamer.com/wp-content/uploads/Pokemon_UNITE_-_Gameplay_Trailer_-_Hero_Image.jpg',
+      info: 'Fortnite',
+      src: 'https://babble.gg/img/banners/fortnite.png',
     },
   ];
 
@@ -90,7 +85,8 @@ const GameList = () => {
       ([entry]) => {
         entry.target.classList.toggle(
           'stuck',
-          entry.intersectionRatio < 1 && !entry.isIntersecting
+          // entry.intersectionRatio <= 0.99 && !entry.isIntersecting
+          entry.boundingClientRect.top <= 0 && !entry.isIntersecting
         );
       },
       { threshold: 1 }

--- a/front/src/pages/GameList/GameList.scss
+++ b/front/src/pages/GameList/GameList.scss
@@ -7,7 +7,7 @@
   padding-bottom: 5rem;
 
   .headline2 {
-    margin: 5rem 0 3rem 0;
+    margin: 5rem 0 4rem 0;
   }
 
   .search-container {

--- a/front/style/_mixins.scss
+++ b/front/style/_mixins.scss
@@ -4,6 +4,7 @@
 @mixin search-container {
   max-width: 100%;
   padding: 1rem 0;
+  margin-bottom: 1rem;
   position: sticky;
   top: -1px;
   background: transparent;
@@ -13,7 +14,7 @@
 @mixin search-section {
   max-width: 100%;
   min-width: 40rem;
-  padding: 1rem 0;
+  padding: 0;
   margin-bottom: 1rem;
   display: flex;
   background-color: f.grey-scale(white);


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
![image](https://user-images.githubusercontent.com/42052110/129303048-3090091c-e250-4dce-9cce-5e8cf646a4f5.png)


## 🔥 구현 내용 요약
- 별도 제작 배너 이미지 적용
- 스크롤 sticky 경계에 걸치면 스타일이 빠른 속도로 toggle되는 버그 수정

## ☠ 트러블 슈팅
