### PR TITLE
fix: 유저가 방에서 제대로 나가지지 않는 버그 수정

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/domain/Session.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/Session.java
@@ -17,11 +17,13 @@ import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Where(clause = "deleted=false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Session {

--- a/back/babble/src/main/java/gg/babble/babble/domain/game/Game.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/game/Game.java
@@ -15,8 +15,10 @@ import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Getter
+@Where(clause = "deleted=false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Game {

--- a/back/babble/src/main/java/gg/babble/babble/domain/room/Room.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/room/Room.java
@@ -23,11 +23,13 @@ import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Where(clause = "deleted=false")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Room {

--- a/back/babble/src/test/resources/websocket-context.sql
+++ b/back/babble/src/test/resources/websocket-context.sql
@@ -14,5 +14,6 @@ insert into tag (`name`) values ('tag1');
 insert into user (avatar, nickname) values ('abc', '와일더');
 insert into user (avatar, nickname) values ('abc', '루트');
 insert into user (avatar, nickname) values ('abc', '포츈');
+insert into user (avatar, nickname) values ('abc', '현구막');
 insert into room (created_at, deleted, game_id, max_headcount) values ('2021-08-11T20:07:09.198', false, (select id from game where name = 'game1' limit 1), 4);
 insert into tag_registration (room_id, tag_id) values ((select id from room limit 1), (select  id from tag limit 1));


### PR DESCRIPTION
## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약

논리적 삭제 사용하는 Entity에 `@Where` 어노테이션 사용

## ☠ 트러블 슈팅

### 논리적 삭제를 하고 있는 Entity가 지연 로딩시 삭제된 엔티티도 불러오는 문제

#### 문제 상황

```java
@EntityListeners(AuditingEntityListener.class)
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity
public class Room {

		@OneToMany(mappedBy = "room")
    private final List<Session> sessions = new ArrayList<>();

		//...
}
```

```java
@EntityListeners(AuditingEntityListener.class)
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity
public class Session {

		@Column(nullable = false)
    private boolean deleted = false;

		//...

		public void delete() {
        if (user.isLinkedSession(this)) {
            user.unLinkSession(this);
        }
        if (room.containsSession(this)) {
            room.exitSession(this);
        }
        deleted = true;
    }
}
```

`Session`은 논리적 삭제를 사용하고 있는데, `Room`의 `sessions`필드가 지연로딩 될 때, 논리적 삭제를 사용하고 있는 것을 모르기 때문에 모든 session을 가지고 오는 문제가 있었다.

#### 해결

Hibernate에서 제공해주는 어노테이션인 `@Where` 어노테이션을 이용했다. 이 어노테이션으로 해당 엔티티를 조회하는 모든 쿼리에 where절이 추가된다.

```java
@EntityListeners(AuditingEntityListener.class)
@Getter
@Where(clause = "deleted=false")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity
public class Session {

	//...

}
```

이 어노테이션을 사용할 때 주의해야될 점이 있다. SQL문에 해당 어노테이션의 문구를 삽입하는 것이기때문에, 이미 영속성 컨텍스트 내에 있는 엔티티의 경우 `deleted`를 `true`로 바꿔도 영속성 컨텍스트에는 남아있으니 유의해야된다. 

#### 참고 자료

[https://www.baeldung.com/spring-jpa-soft-delete#how-to-get-the-deleted-data](https://www.baeldung.com/spring-jpa-soft-delete#how-to-get-the-deleted-data)

[https://www.baeldung.com/hibernate-dynamic-mapping#filtering-entities-with-where](https://www.baeldung.com/hibernate-dynamic-mapping#filtering-entities-with-where)

[https://stackoverflow.com/questions/40254962/hibernate-soft-deletion-for-child-table](https://stackoverflow.com/questions/40254962/hibernate-soft-deletion-for-child-table)