### PR TITLE
feat: Sliders 관련 기능 구현

### DIFF
--- a/.idea/2021-babble.iml
+++ b/.idea/2021-babble.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/2021-babble.iml" filepath="$PROJECT_DIR$/.idea/2021-babble.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="d785c5ea-82ad-429c-af4c-9cf1e20d2313" name="Default Changelist" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="1xkmQT5vDXaL5hfsMOXutPS71iX" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="aspect.path.notification.shown" value="true" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="d785c5ea-82ad-429c-af4c-9cf1e20d2313" name="Default Changelist" comment="" />
+      <created>1630907444699</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1630907444699</updated>
+      <workItem from="1630907446158" duration="21000" />
+    </task>
+    <servers />
+  </component>
+</project>

--- a/back/babble/src/main/java/gg/babble/babble/controller/SliderController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/SliderController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,13 +32,13 @@ public class SliderController {
     }
 
     @PostMapping
-    public ResponseEntity<SliderResponse> insertSliders(final SliderRequest request) {
+    public ResponseEntity<SliderResponse> insertSliders(@RequestBody final SliderRequest request) {
         SliderResponse response = sliderService.insert(request);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping
-    public ResponseEntity<List<SliderResponse>> updateOrder(final SliderOrderRequest request) {
+    public ResponseEntity<List<SliderResponse>> updateOrder(@RequestBody final SliderOrderRequest request) {
         List<SliderResponse> sliderResponses = sliderService.updateOrder(request);
         return ResponseEntity.ok(sliderResponses);
     }

--- a/back/babble/src/main/java/gg/babble/babble/controller/SliderController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/SliderController.java
@@ -1,0 +1,50 @@
+package gg.babble.babble.controller;
+
+import gg.babble.babble.dto.request.SliderOrderRequest;
+import gg.babble.babble.dto.request.SliderRequest;
+import gg.babble.babble.dto.response.SliderResponse;
+import gg.babble.babble.service.SliderService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/api/sliders")
+@RestController
+public class SliderController {
+
+    private final SliderService sliderService;
+
+    public SliderController(SliderService sliderService) {
+        this.sliderService = sliderService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SliderResponse>> findAllSliders() {
+        List<SliderResponse> responses = sliderService.findAll();
+        return ResponseEntity.ok(responses);
+    }
+
+    @PostMapping
+    public ResponseEntity<SliderResponse> insertSliders(final SliderRequest request) {
+        SliderResponse response = sliderService.insert(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    public ResponseEntity<List<SliderResponse>> updateOrder(final SliderOrderRequest request) {
+        List<SliderResponse> sliderResponses = sliderService.updateOrder(request);
+        return ResponseEntity.ok(sliderResponses);
+    }
+
+    @DeleteMapping(value = "/{sliderId}")
+    public ResponseEntity<Void> delete(@PathVariable Long sliderId) {
+        sliderService.delete(sliderId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/repository/SliderRepository.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/repository/SliderRepository.java
@@ -1,0 +1,8 @@
+package gg.babble.babble.domain.repository;
+
+import gg.babble.babble.domain.slider.Slider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SliderRepository extends JpaRepository<Slider, Long> {
+
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/slider/ResourceUrl.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/slider/ResourceUrl.java
@@ -1,0 +1,18 @@
+package gg.babble.babble.domain.slider;
+
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class ResourceUrl {
+
+    private String url;
+
+    public ResourceUrl(String url) {
+        this.url = url;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/domain/slider/Slider.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/slider/Slider.java
@@ -1,0 +1,43 @@
+package gg.babble.babble.domain.slider;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Slider {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private ResourceUrl resourceUrl;
+
+    private int sortingIndex;
+
+    public Slider(final String url) {
+        this(null, new ResourceUrl(url), Integer.MAX_VALUE);
+    }
+
+    public Slider(final Long id, final ResourceUrl resourceUrl, final int sortingIndex) {
+        this.id = id;
+        this.resourceUrl = resourceUrl;
+        this.sortingIndex = sortingIndex;
+    }
+
+    public String url() {
+        return resourceUrl.getUrl();
+    }
+
+    public void setSortingIndex(final int sortingIndex) {
+        this.sortingIndex = sortingIndex;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/request/SliderOrderRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/request/SliderOrderRequest.java
@@ -1,0 +1,16 @@
+package gg.babble.babble.dto.request;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SliderOrderRequest {
+
+    private List<Long> ids;
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/request/SliderRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/request/SliderRequest.java
@@ -1,0 +1,22 @@
+package gg.babble.babble.dto.request;
+
+import com.sun.istack.NotNull;
+import gg.babble.babble.domain.slider.Slider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SliderRequest {
+
+    @NotNull
+    private String sliderUrl;
+
+    public Slider toEntity() {
+        return new Slider(sliderUrl);
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/response/SliderResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/response/SliderResponse.java
@@ -1,0 +1,19 @@
+package gg.babble.babble.dto.response;
+
+import gg.babble.babble.domain.slider.Slider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class SliderResponse {
+
+    private final Long id;
+    private final String url;
+
+    public static SliderResponse from(final Slider slider) {
+        return new SliderResponse(slider.getId(), slider.url());
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/service/SliderService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/SliderService.java
@@ -1,0 +1,78 @@
+package gg.babble.babble.service;
+
+import gg.babble.babble.domain.repository.SliderRepository;
+import gg.babble.babble.domain.slider.Slider;
+import gg.babble.babble.dto.request.SliderOrderRequest;
+import gg.babble.babble.dto.request.SliderRequest;
+import gg.babble.babble.dto.response.SliderResponse;
+import gg.babble.babble.exception.BabbleNotFoundException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class SliderService {
+
+    private final SliderRepository sliderRepository;
+
+    public SliderService(final SliderRepository sliderRepository) {
+        this.sliderRepository = sliderRepository;
+    }
+
+    @Transactional
+    public SliderResponse insert(final SliderRequest request) {
+        Slider slider = sliderRepository.save(request.toEntity());
+        return SliderResponse.from(slider);
+    }
+
+    public List<SliderResponse> findAll() {
+        List<Slider> sliders = sliderRepository.findAll();
+        sliders.sort(Comparator.comparingInt(Slider::getSortingIndex));
+
+        return sliders.stream()
+            .map(SliderResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<SliderResponse> updateOrder(SliderOrderRequest request) {
+        Map<Long, Slider> dictionary = listToMap(sliderRepository.findAll());
+        sort(dictionary, request.getIds());
+
+        List<Slider> changed = new ArrayList<>(dictionary.values());
+        sliderRepository.saveAll(changed);
+
+        return changed.stream()
+            .map(SliderResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    private Map<Long, Slider> listToMap(List<Slider> sliders) {
+        Map<Long, Slider> dictionary = new HashMap<>();
+
+        for (Slider slider : sliders) {
+            dictionary.put(slider.getId(), slider);
+        }
+
+        return dictionary;
+    }
+
+    private void sort(Map<Long, Slider> dictionary, List<Long> ids) {
+        for (int i = 0; i < ids.size(); i++) {
+            Slider slider = dictionary.get(ids.get(i));
+            slider.setSortingIndex(i);
+        }
+    }
+
+    @Transactional
+    public void delete(Long sliderId) {
+        Slider slider = sliderRepository.findById(sliderId).orElseThrow(BabbleNotFoundException::new);
+        sliderRepository.delete(slider);
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/service/SliderService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/SliderService.java
@@ -49,6 +49,7 @@ public class SliderService {
         sliderRepository.saveAll(changed);
 
         return changed.stream()
+            .sorted(Comparator.comparingInt(Slider::getSortingIndex))
             .map(SliderResponse::from)
             .collect(Collectors.toList());
     }

--- a/back/babble/src/main/resources/db/migration/V8__add_table_slider.sql
+++ b/back/babble/src/main/resources/db/migration/V8__add_table_slider.sql
@@ -1,0 +1,7 @@
+create table slider
+(
+    id            bigint auto_increment,
+    url           varchar(255) not null,
+    sorting_index integer      not null,
+    primary key (id)
+);

--- a/back/babble/src/test/java/gg/babble/babble/ApplicationTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/ApplicationTest.java
@@ -6,6 +6,7 @@ import gg.babble.babble.domain.repository.AlternativeTagNameRepository;
 import gg.babble.babble.domain.repository.GameRepository;
 import gg.babble.babble.domain.repository.RoomRepository;
 import gg.babble.babble.domain.repository.SessionRepository;
+import gg.babble.babble.domain.repository.SliderRepository;
 import gg.babble.babble.domain.repository.TagRepository;
 import gg.babble.babble.domain.repository.UserRepository;
 import io.restassured.RestAssured;
@@ -46,6 +47,9 @@ public class ApplicationTest {
 
     @Autowired
     protected TagRepository tagRepository;
+
+    @Autowired
+    protected SliderRepository sliderRepository;
 
     @BeforeEach
     protected void setUp() {

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/SliderApiDocumentTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/SliderApiDocumentTest.java
@@ -1,0 +1,129 @@
+package gg.babble.babble.restdocs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gg.babble.babble.domain.admin.Administrator;
+import gg.babble.babble.domain.slider.ResourceUrl;
+import gg.babble.babble.domain.slider.Slider;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.web.context.WebApplicationContext;
+
+public class SliderApiDocumentTest extends ApiDocumentTest {
+
+    private Slider slider1;
+    private Slider slider2;
+    private Slider slider3;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        super.setUp(webApplicationContext, restDocumentation);
+
+        slider1 = sliderRepository.save(new Slider("test/url/1"));
+        slider2 = sliderRepository.save(new Slider("test/url/2"));
+        slider3 = sliderRepository.save(new Slider("test/url/3"));
+
+        administratorRepository.save(new Administrator("127.0.0.1", "localhost"));
+    }
+
+    @DisplayName("전체 슬라이더를 조회한다.")
+    @Test
+    public void findAllSliders() throws Exception {
+        mockMvc.perform(get("/api/sliders")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(slider1.getId()))
+            .andExpect(jsonPath("$[0].url").value(slider1.url()))
+            .andExpect(jsonPath("$[1].id").value(slider2.getId()))
+            .andExpect(jsonPath("$[1].url").value(slider2.url()))
+            .andExpect(jsonPath("$[2].id").value(slider3.getId()))
+            .andExpect(jsonPath("$[2].url").value(slider3.url()))
+
+            .andDo(document("read-slider",
+                responseFields(
+                    fieldWithPath("[].id").description("슬라이더 Id"),
+                    fieldWithPath("[].url").description("주소"))
+            ));
+    }
+
+    @DisplayName("슬라이더를 추가한다.")
+    @Test
+    public void insertSlider() throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        body.put("sliderUrl", "testPath");
+        mockMvc.perform(post("/api/sliders")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(body)).characterEncoding("utf-8"))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").isNumber())
+            .andExpect(jsonPath("$.url").isString())
+
+            .andDo(document("insert-slider",
+                requestFields(fieldWithPath("sliderUrl").description("주소")),
+                responseFields(fieldWithPath("id").description("슬라이더 Id"),
+                    fieldWithPath("url").description("주소"))
+            ));
+    }
+
+    @DisplayName("슬라이더 순서를 변경한다.")
+    @Test
+    public void updateSlider() throws Exception {
+        Map<String, Object> body = new HashMap<>();
+        List<Long> ids = Arrays.asList(slider1.getId(), slider3.getId(), slider2.getId());
+        body.put("ids", ids);
+        mockMvc.perform(put("/api/sliders")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsString(body)).characterEncoding("utf-8"))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(slider1.getId()))
+            .andExpect(jsonPath("$[0].url").value(slider1.url()))
+            .andExpect(jsonPath("$[1].id").value(slider3.getId()))
+            .andExpect(jsonPath("$[1].url").value(slider3.url()))
+            .andExpect(jsonPath("$[2].id").value(slider2.getId()))
+            .andExpect(jsonPath("$[2].url").value(slider2.url()))
+
+            .andDo(document("update-slider-order",
+                requestFields(fieldWithPath("ids").description("슬라이더 Id")),
+                responseFields(fieldWithPath("[].id").description("슬라이더 Id"),
+                    fieldWithPath("[].url").description("주소"))
+            ));
+    }
+
+    @DisplayName("슬라이더를 제거한다.")
+    @Test
+    public void deleteSlider() throws Exception {
+        mockMvc.perform(delete("/api/sliders/" + slider1.getId())
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent())
+            .andDo(document("delete-slider"));
+
+        mockMvc.perform(get("/api/sliders")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].id").value(slider2.getId()))
+            .andExpect(jsonPath("$[0].url").value(slider2.url()))
+            .andExpect(jsonPath("$[1].id").value(slider3.getId()))
+            .andExpect(jsonPath("$[1].url").value(slider3.url()));
+    }
+}

--- a/back/babble/src/test/java/gg/babble/babble/service/SliderServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/SliderServiceTest.java
@@ -1,0 +1,83 @@
+package gg.babble.babble.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.domain.slider.Slider;
+import gg.babble.babble.dto.request.SliderOrderRequest;
+import gg.babble.babble.dto.request.SliderRequest;
+import gg.babble.babble.dto.response.SliderResponse;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SliderServiceTest extends ApplicationTest {
+
+    private Slider slider1;
+    private Slider slider2;
+    private Slider slider3;
+
+    @Autowired
+    private SliderService sliderService;
+
+    @BeforeEach
+    public void setUp() {
+        slider1 = sliderRepository.save(new Slider("test1/path"));
+        slider2 = sliderRepository.save(new Slider("test2/path"));
+        slider3 = sliderRepository.save(new Slider("test3/path"));
+    }
+
+    @DisplayName("슬라이더 이미지를 추가한다.")
+    @Test
+    void insert() {
+        SliderRequest request = new SliderRequest("test/path");
+        SliderResponse response = sliderService.insert(request);
+
+        SliderResponse expected = SliderResponse.from(new Slider("test/path"));
+
+        assertThat(response).usingRecursiveComparison().ignoringFields("id").isEqualTo(expected);
+    }
+
+    @DisplayName("전체 슬라이더 이미지를 가져온다.")
+    @Test
+    void findAll() {
+        List<SliderResponse> sliders = sliderService.findAll();
+        List<SliderResponse> expected = Arrays.asList(
+            SliderResponse.from(slider1),
+            SliderResponse.from(slider2),
+            SliderResponse.from(slider3)
+        );
+
+        assertThat(sliders).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @DisplayName("슬라이더 이미지를 순서를 변경한다.")
+    @Test
+    void update() {
+        SliderOrderRequest request = new SliderOrderRequest(Arrays.asList(slider3.getId(), slider1.getId(), slider2.getId()));
+        List<SliderResponse> responses = sliderService.updateOrder(request);
+
+        List<SliderResponse> expected = Arrays.asList(SliderResponse.from(slider3)
+            , SliderResponse.from(slider1)
+            , SliderResponse.from(slider2)
+        );
+
+        assertThat(responses).usingRecursiveComparison().ignoringFields("id").isEqualTo(expected);
+    }
+
+    @DisplayName("슬라이더 이미지를 제거한다.")
+    @Test
+    void delete() {
+        sliderService.delete(slider2.getId());
+        List<SliderResponse> sliders = sliderService.findAll();
+        List<SliderResponse> expected = Arrays.asList(
+            SliderResponse.from(slider1),
+            SliderResponse.from(slider3)
+        );
+
+        assertThat(sliders).usingRecursiveComparison().isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Closes #376 

## 🔥 구현 내용 요약
Slider API 를 구현했습니다.
구현 과정중에 `sortingLayer` 라는 컬럼이 추가되었는데 초반 설계된 API 는 차이가 없습니다.
`관리자용 IP 관련 이슈`는 최근에 `IP 가 임의로 변경될 수 있지 않냐?`라는 의견에 의해 구현하지 않은 상태입니다.
현재 여러 팀원이 동시에 관리자용 API 를 구현중이기 때문에 `RestDocs Ascii` 파일은 수정하지 않은 상태입니다.

## ☠ 트러블 슈팅
Flyway 설정 오류였는데 이 부분은 디버그 레벨에서 알려주는 오류 메세지를 통해 해결할 수 있었습니다.
