### PR TITLE
feat: 관리자 태그 관리 API 구현

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
@@ -6,6 +6,7 @@ import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.service.TagService;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,5 +41,11 @@ public class TagController {
                                                  @RequestBody final TagUpdateRequest request) {
         TagResponse response = tagService.updateTag(tagId, request);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping(value = "/{tagId}")
+    public ResponseEntity<Void> deleteTag(@PathVariable final Long tagId) {
+        tagService.deleteTag(tagId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
@@ -4,7 +4,6 @@ import gg.babble.babble.dto.request.TagCreateRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.service.TagService;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +29,6 @@ public class TagController {
     @PostMapping
     public ResponseEntity<TagResponse> createTag(@RequestBody TagCreateRequest request) {
         TagResponse response = tagService.createTag(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.ok(response);
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
@@ -1,10 +1,14 @@
 package gg.babble.babble.controller;
 
+import gg.babble.babble.dto.request.TagCreateRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.service.TagService;
 import java.util.List;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +25,11 @@ public class TagController {
     @GetMapping
     public ResponseEntity<List<TagResponse>> getAllTags() {
         return ResponseEntity.ok(tagService.findAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<TagResponse> createTag(@RequestBody TagCreateRequest request) {
+        TagResponse response = tagService.createTag(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
+++ b/back/babble/src/main/java/gg/babble/babble/controller/TagController.java
@@ -1,12 +1,15 @@
 package gg.babble.babble.controller;
 
 import gg.babble.babble.dto.request.TagCreateRequest;
+import gg.babble.babble.dto.request.TagUpdateRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.service.TagService;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,8 +30,15 @@ public class TagController {
     }
 
     @PostMapping
-    public ResponseEntity<TagResponse> createTag(@RequestBody TagCreateRequest request) {
+    public ResponseEntity<TagResponse> createTag(@RequestBody final TagCreateRequest request) {
         TagResponse response = tagService.createTag(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping(value = "/{tagId}")
+    public ResponseEntity<TagResponse> updateTag(@PathVariable final Long tagId,
+                                                 @RequestBody final TagUpdateRequest request) {
+        TagResponse response = tagService.updateTag(tagId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/domain/game/AlternativeGameName.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/game/AlternativeGameName.java
@@ -51,9 +51,7 @@ public class AlternativeGameName {
             previousGame.removeAlternativeName(this);
         }
 
-        if (game.hasNotName(value)) {
-            game.addAlternativeName(this);
-        }
+        game.addAlternativeName(this);
     }
 
     public void delete() {

--- a/back/babble/src/main/java/gg/babble/babble/domain/game/AlternativeGameNames.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/game/AlternativeGameNames.java
@@ -2,10 +2,9 @@ package gg.babble.babble.domain.game;
 
 import gg.babble.babble.exception.BabbleDuplicatedException;
 import gg.babble.babble.exception.BabbleNotFoundException;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -19,9 +18,9 @@ public class AlternativeGameNames {
 
     @OneToMany(mappedBy = "game")
     @NotNull(message = "대안 이름들은 Null 일 수 없습니다.")
-    private Set<AlternativeGameName> elements = new HashSet<>();
+    private List<AlternativeGameName> elements = new ArrayList<>();
 
-    public AlternativeGameNames(final Set<AlternativeGameName> elements) {
+    public AlternativeGameNames(final List<AlternativeGameName> elements) {
         this.elements = elements;
     }
 
@@ -29,6 +28,7 @@ public class AlternativeGameNames {
         if (contains(name.getValue())) {
             throw new BabbleDuplicatedException(String.format("이미 존재하는 이름 입니다.(%s)", name.getValue()));
         }
+
         elements.add(name);
     }
 

--- a/back/babble/src/main/java/gg/babble/babble/domain/repository/TagRepository.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/repository/TagRepository.java
@@ -1,8 +1,13 @@
 package gg.babble.babble.domain.repository;
 
 import gg.babble.babble.domain.tag.Tag;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
+    List<Tag> findByDeletedFalse();
+
+    Optional<Tag> findByIdAndDeletedFalse(final Long id);
 }

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagName.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagName.java
@@ -44,16 +44,14 @@ public class AlternativeTagName {
     }
 
     public void setTag(final Tag tag) {
-        final Tag previousTag = this.tag;
+        Tag previousTag = this.tag;
         this.tag = tag;
 
         if (Objects.nonNull(previousTag) && previousTag.hasName(value)) {
             previousTag.removeAlternativeName(this);
         }
 
-        if (tag.hasNotName(value)) {
-            tag.addAlternativeName(this);
-        }
+        tag.addAlternativeName(this);
     }
 
     public void delete() {

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagName.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagName.java
@@ -54,15 +54,17 @@ public class AlternativeTagName {
         tag.addAlternativeName(this);
     }
 
+    // TODO: 동시성 문제가 발생해서 연관관계를 끊지 않도록 했다.
     public void delete() {
-        if (tag.hasName(value)) {
-            tag.removeAlternativeName(this);
-        }
         isDeleted = true;
     }
 
     public boolean isSameName(final TagName name) {
         return value.equals(name);
+    }
+
+    public boolean isNotDeleted() {
+        return !isDeleted();
     }
 
     @Override

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
@@ -31,6 +31,7 @@ public class AlternativeTagNames {
         if (contains(name.getValue())) {
             throw new BabbleDuplicatedException(String.format("이미 존재하는 이름 입니다.(%s)", name.getValue()));
         }
+
         elements.add(name);
     }
 
@@ -39,18 +40,24 @@ public class AlternativeTagNames {
             throw new BabbleNotFoundException(String.format("존재하지 않는 이름 입니다.(%s)", alternativeTagName.getValue().getValue()));
         }
 
-        elements.remove(alternativeTagName);
+        alternativeTagName.delete();
     }
 
     public boolean contains(final TagName name) {
-        return elements.stream()
+        return getElements().stream()
             .anyMatch(alternativeName -> alternativeName.isSameName(name));
     }
 
     public List<String> getNames() {
-        return elements.stream()
+        return getElements().stream()
             .map(AlternativeTagName::getValue)
             .map(TagName::getValue)
+            .collect(Collectors.toList());
+    }
+
+    private List<AlternativeTagName> getElements() {
+        return elements.stream()
+            .filter(AlternativeTagName::isNotDeleted)
             .collect(Collectors.toList());
     }
 

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
@@ -2,7 +2,9 @@ package gg.babble.babble.domain.tag;
 
 import gg.babble.babble.exception.BabbleDuplicatedException;
 import gg.babble.babble.exception.BabbleNotFoundException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,13 +17,13 @@ public class AlternativeTagNames {
 
     @OneToMany(mappedBy = "tag")
     @NotNull(message = "대안 이름들은 Null 일 수 없습니다.")
-    private final Set<AlternativeTagName> elements;
+    private final List<AlternativeTagName> elements;
 
     public AlternativeTagNames() {
-        this(new HashSet<>());
+        this(new ArrayList<>());
     }
 
-    public AlternativeTagNames(final Set<AlternativeTagName> elements) {
+    public AlternativeTagNames(final List<AlternativeTagName> elements) {
         this.elements = elements;
     }
 

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
@@ -3,10 +3,8 @@ package gg.babble.babble.domain.tag;
 import gg.babble.babble.exception.BabbleDuplicatedException;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -41,6 +39,12 @@ public class AlternativeTagNames {
         }
 
         alternativeTagName.delete();
+    }
+
+    public void deleteAll() {
+        for (AlternativeTagName element : getElements()) {
+            element.delete();
+        }
     }
 
     public boolean contains(final TagName name) {

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/AlternativeTagNames.java
@@ -47,11 +47,11 @@ public class AlternativeTagNames {
             .anyMatch(alternativeName -> alternativeName.isSameName(name));
     }
 
-    public Set<String> getNames() {
+    public List<String> getNames() {
         return elements.stream()
             .map(AlternativeTagName::getValue)
             .map(TagName::getValue)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
     }
 
     @Override

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/Tag.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/Tag.java
@@ -1,8 +1,10 @@
 package gg.babble.babble.domain.tag;
 
 import gg.babble.babble.exception.BabbleDuplicatedException;
+import gg.babble.babble.exception.BabbleIllegalStatementException;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.Objects;
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -29,6 +31,9 @@ public class Tag {
 
     @Embedded
     private TagRegistrationsOfTag tagRegistrations;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 
     public Tag(final String name) {
         this(null, name);
@@ -68,10 +73,15 @@ public class Tag {
         }
 
         alternativeTagNames.remove(alternativeTagName);
+    }
 
-        if (alternativeTagName.getTag().equals(this)) {
-            alternativeTagName.delete();
+    public void delete() {
+        if (tagRegistrations.isNotEmpty()) {
+            throw new BabbleIllegalStatementException(String.format("(%d) 태그를 사용중인 방이 있어 삭제를 할 수 없습니다.", id));
         }
+
+        alternativeTagNames.deleteAll();
+        deleted = true;
     }
 
     public boolean hasName(final TagName name) {

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/Tag.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/Tag.java
@@ -57,6 +57,11 @@ public class Tag {
         }
     }
 
+    public void update(Tag target) {
+        this.name = target.name;
+        this.alternativeTagNames = target.alternativeTagNames;
+    }
+
     public void removeAlternativeName(final AlternativeTagName alternativeTagName) {
         if (hasNotName(alternativeTagName.getValue())) {
             throw new BabbleNotFoundException(String.format("존재하지 않는 이름 입니다.(%s)", alternativeTagName.getValue()));

--- a/back/babble/src/main/java/gg/babble/babble/domain/tag/TagRegistrationsOfTag.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/tag/TagRegistrationsOfTag.java
@@ -1,6 +1,7 @@
 package gg.babble.babble.domain.tag;
 
 import gg.babble.babble.domain.TagRegistration;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
@@ -9,6 +10,9 @@ import javax.persistence.OneToMany;
 public class TagRegistrationsOfTag {
 
     @OneToMany(mappedBy = "tag")
-    private List<TagRegistration> tagRegistrations;
+    private List<TagRegistration> tagRegistrations = new ArrayList<>();
 
+    public boolean isNotEmpty() {
+        return !tagRegistrations.isEmpty();
+    }
 }

--- a/back/babble/src/main/java/gg/babble/babble/dto/request/TagCreateRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/request/TagCreateRequest.java
@@ -1,0 +1,25 @@
+package gg.babble.babble.dto.request;
+
+import gg.babble.babble.domain.tag.AlternativeTagName;
+import gg.babble.babble.domain.tag.Tag;
+import java.util.List;
+
+public class TagCreateRequest {
+
+    private String name;
+    private List<String> alternativeNames;
+
+    public TagCreateRequest() {
+    }
+
+    public TagCreateRequest(String name, List<String> alternativeNames) {
+        this.name = name;
+        this.alternativeNames = alternativeNames;
+    }
+
+    public Tag toEntity() {
+        Tag tag = new Tag(name);
+        alternativeNames.forEach(alternativeName -> new AlternativeTagName(alternativeName, tag));
+        return tag;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/request/TagUpdateRequest.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/request/TagUpdateRequest.java
@@ -1,0 +1,25 @@
+package gg.babble.babble.dto.request;
+
+import gg.babble.babble.domain.tag.AlternativeTagName;
+import gg.babble.babble.domain.tag.Tag;
+import java.util.List;
+
+public class TagUpdateRequest {
+
+    private String name;
+    private List<String> alternativeNames;
+
+    public TagUpdateRequest() {
+    }
+
+    public TagUpdateRequest(String name, List<String> alternativeNames) {
+        this.name = name;
+        this.alternativeNames = alternativeNames;
+    }
+
+    public Tag toEntity() {
+        Tag tag = new Tag(name);
+        alternativeNames.forEach(alternativeName -> new AlternativeTagName(alternativeName, tag));
+        return tag;
+    }
+}

--- a/back/babble/src/main/java/gg/babble/babble/dto/response/TagResponse.java
+++ b/back/babble/src/main/java/gg/babble/babble/dto/response/TagResponse.java
@@ -1,7 +1,7 @@
 package gg.babble.babble.dto.response;
 
 import gg.babble.babble.domain.tag.Tag;
-import java.util.Set;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,7 +11,7 @@ public class TagResponse {
 
     private final Long id;
     private final String name;
-    private final Set<String> alternativeNames;
+    private final List<String> alternativeNames;
 
     public static TagResponse from(final Tag tag) {
         return new TagResponse(tag.getId(), tag.getName(), tag.getAlternativeTagNames().getNames());

--- a/back/babble/src/main/java/gg/babble/babble/service/TagService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/TagService.java
@@ -2,6 +2,7 @@ package gg.babble.babble.service;
 
 import gg.babble.babble.domain.repository.TagRepository;
 import gg.babble.babble.domain.tag.Tag;
+import gg.babble.babble.dto.request.TagCreateRequest;
 import gg.babble.babble.dto.request.TagRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
@@ -37,5 +38,15 @@ public class TagService {
         return tags.stream()
             .map(TagResponse::from)
             .collect(Collectors.toList());
+    }
+
+
+    // TODO: Set 자료구조를 전부 List로 바꿨다. 엔티티간 id를 통해 동일성 비교를 하기 때문에 컬렉션에서 지워진 채로 1개만 삽입됐다.
+    // TODO: AlternativeName은 Game이나 Tag에 종속적인 존재기 때문에, 이전에 포츈이 사용한 어노테이션 그걸로 바꿔보는걸 고려하자.
+    @Transactional
+    public TagResponse createTag(TagCreateRequest request) {
+        Tag tag = tagRepository.save(request.toEntity());
+
+        return TagResponse.from(tag);
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/service/TagService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/TagService.java
@@ -29,12 +29,12 @@ public class TagService {
     }
 
     private Tag findById(final Long id) {
-        return tagRepository.findById(id)
+        return tagRepository.findByIdAndDeletedFalse(id)
             .orElseThrow(() -> new BabbleNotFoundException(String.format("[%d]는 존재하지 않는 태그 ID입니다.", id)));
     }
 
     public List<TagResponse> findAll() {
-        List<Tag> tags = tagRepository.findAll();
+        List<Tag> tags = tagRepository.findByDeletedFalse();
 
         return tags.stream()
             .map(TagResponse::from)
@@ -45,16 +45,24 @@ public class TagService {
     // TODO: Set 자료구조를 전부 List로 바꿨다. 엔티티간 id를 통해 동일성 비교를 하기 때문에 컬렉션에서 지워진 채로 1개만 삽입됐다.
     // TODO: AlternativeName은 Game이나 Tag에 종속적인 존재기 때문에, 이전에 포츈이 사용한 어노테이션 그걸로 바꿔보는걸 고려하자.
     @Transactional
-    public TagResponse createTag(TagCreateRequest request) {
+    public TagResponse createTag(final TagCreateRequest request) {
         Tag tag = tagRepository.save(request.toEntity());
 
         return TagResponse.from(tag);
     }
 
-    public TagResponse updateTag(Long tagId, TagUpdateRequest request) {
+    @Transactional
+    public TagResponse updateTag(final Long tagId, final TagUpdateRequest request) {
         Tag tag = findById(tagId);
         tag.update(request.toEntity());
 
         return TagResponse.from(tag);
+    }
+
+    // TODO: 태그를 삭제할 때 대체 이름과 관계를 유지시킬 것인지? 아니면 그냥 관계도 끊어버릴 것인지?
+    @Transactional
+    public void deleteTag(final Long tagId) {
+        Tag tag = findById(tagId);
+        tag.delete();
     }
 }

--- a/back/babble/src/main/java/gg/babble/babble/service/TagService.java
+++ b/back/babble/src/main/java/gg/babble/babble/service/TagService.java
@@ -4,6 +4,7 @@ import gg.babble.babble.domain.repository.TagRepository;
 import gg.babble.babble.domain.tag.Tag;
 import gg.babble.babble.dto.request.TagCreateRequest;
 import gg.babble.babble.dto.request.TagRequest;
+import gg.babble.babble.dto.request.TagUpdateRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.List;
@@ -46,6 +47,13 @@ public class TagService {
     @Transactional
     public TagResponse createTag(TagCreateRequest request) {
         Tag tag = tagRepository.save(request.toEntity());
+
+        return TagResponse.from(tag);
+    }
+
+    public TagResponse updateTag(Long tagId, TagUpdateRequest request) {
+        Tag tag = findById(tagId);
+        tag.update(request.toEntity());
 
         return TagResponse.from(tag);
     }

--- a/back/babble/src/main/resources/db/migration/V10__tag_add_column_deleted.sql
+++ b/back/babble/src/main/resources/db/migration/V10__tag_add_column_deleted.sql
@@ -1,0 +1,1 @@
+alter table tag add deleted boolean not null;

--- a/back/babble/src/test/java/gg/babble/babble/domain/game/GameTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/game/GameTest.java
@@ -71,23 +71,26 @@ class GameTest {
         final AlternativeGameName alternativeGameName = new AlternativeGameName("망겜", game);
 
         // then
-        assertThat(game.getAlternativeGameNames()).isEqualTo(new AlternativeGameNames(Collections.singleton(alternativeGameName)));
+        assertThat(game.getAlternativeGameNames()).isEqualTo(new AlternativeGameNames(Collections.singletonList(alternativeGameName)));
     }
 
     @DisplayName("대체 이름 변경")
     @Test
     void changeAlternativeGameName() {
         // given
-        Game game = new Game(1L, "오래된 게임", Collections.singletonList("오래된 이미지"));
-        Game game2 = new Game(2L, "최신 게임", Collections.singletonList("최신 이미지"));
+        final Game game = new Game(1L, "오래된 게임", Collections.singletonList("오래된 이미지"));
+        AlternativeGameName alternativeGameName = new AlternativeGameName(1L, "흥겜", game);
+        final Game target = new Game("새로운 게임", Collections.singletonList("새로운 이미지"));
+        AlternativeGameName alternativeTargetGameName = new AlternativeGameName(1L, "망겜", target);
+
         // when
-        final AlternativeGameName alternativeGameName = new AlternativeGameName("흥겜", game);
-        game2.addAlternativeName(alternativeGameName);
+        game.update(target);
+
         // then
-        assertThat(game.hasName(alternativeGameName.getValue())).isFalse();
-        assertThat(game2.hasName(alternativeGameName.getValue())).isTrue();
-        assertThat(alternativeGameName.getGame()).isEqualTo(game2);
-        assertThat(alternativeGameName.isDeleted()).isFalse();
+        assertThat(game.getId()).isEqualTo(1L);
+        assertThat(game.getName()).isEqualTo(target.getName());
+        assertThat(game.getImages()).isEqualTo(target.getImages());
+        assertThat(game.getAlternativeGameNames()).isEqualTo(new AlternativeGameNames(Collections.singletonList(alternativeTargetGameName)));
     }
 
     @DisplayName("대체 이름 삭제")

--- a/back/babble/src/test/java/gg/babble/babble/domain/repository/TagRepositoryTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/repository/TagRepositoryTest.java
@@ -3,6 +3,8 @@ package gg.babble.babble.domain.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gg.babble.babble.domain.tag.Tag;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,5 +28,37 @@ public class TagRepositoryTest {
         // then
         assertThat(savedTag.getId()).isNotNull();
         assertThat(savedTag.getName()).isEqualTo(tag.getName());
+    }
+
+    @DisplayName("전체 태그 조회시 삭제된 태그는 조회하지 않는다.")
+    @Test
+    void findByDeletedFalse() {
+        // given
+        Tag apex_tag = tagRepository.save(new Tag("에이펙스"));
+        Tag bpex_tag = tagRepository.save(new Tag("비펙스"));
+        Tag cpex_tag = tagRepository.save(new Tag("씨펙스"));
+
+        // when
+        List<Tag> beforeDeleteTags = tagRepository.findByDeletedFalse();
+        bpex_tag.delete();
+        List<Tag> afterDeleteTags = tagRepository.findByDeletedFalse();
+
+        // then
+        assertThat(beforeDeleteTags).containsExactly(apex_tag, bpex_tag, cpex_tag);
+        assertThat(afterDeleteTags).containsExactly(apex_tag, cpex_tag);
+    }
+
+    @DisplayName("ID로 태그 조회시 삭제된 태그는 조회하지 않는다.")
+    @Test
+    void findByIdAndDeletedFalse() {
+        // given
+        Tag tag = tagRepository.save(new Tag("똥겜"));
+
+        // when
+        assertThat(tagRepository.findByIdAndDeletedFalse(tag.getId())).isPresent();
+        tag.delete();
+
+        // then
+        assertThat(tagRepository.findByIdAndDeletedFalse(tag.getId())).isNotPresent();
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/domain/tag/AlternativeTagNameTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/tag/AlternativeTagNameTest.java
@@ -23,21 +23,12 @@ class AlternativeTagNameTest {
         assertThat(tag.getAlternativeTagNames().contains(alternativeTagName.getValue())).isTrue();
     }
 
-    @DisplayName("대체 이름의 게임을 변경")
-    @Test
-    void setGame() {
-        final Tag anotherTag = new Tag("2시간");
-        alternativeTagName.setTag(anotherTag);
-
-        assertThat(anotherTag.getAlternativeTagNames().contains(alternativeTagName.getValue())).isTrue();
-        assertThat(tag.getAlternativeTagNames().contains(alternativeTagName.getValue())).isFalse();
-    }
-
     @DisplayName("대체 이름 삭제")
     @Test
     void delete() {
         // when
         alternativeTagName.delete();
+
         // then
         assertThat(tag.hasName(alternativeTagName.getValue())).isFalse();
         assertThat(alternativeTagName.isDeleted()).isTrue();

--- a/back/babble/src/test/java/gg/babble/babble/domain/tag/TagTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/tag/TagTest.java
@@ -37,10 +37,10 @@ class TagTest {
     @Test
     void addAlternativeName() {
         // given
-        final Tag tag = new Tag(1L, "1시간");
+        Tag tag = new Tag(1L, "1시간");
 
         // when
-        final AlternativeTagName alternativeName = new AlternativeTagName("1hour", tag);
+        AlternativeTagName alternativeName = new AlternativeTagName("1hour", tag);
 
         // then
         assertThat(tag.getAlternativeTagNames()).isEqualTo(new AlternativeTagNames(Collections.singletonList(alternativeName)));
@@ -113,32 +113,39 @@ class TagTest {
         assertThat(tag.getAlternativeTagNames().getNames()).containsExactly(updateAlternativeTagName);
     }
 
-    @DisplayName("단일 대체 이름 변경")
-    @Test
-    void changeAlternativeName() {
-        // given
-        final Tag tag = new Tag(1L, "1시간");
-        final Tag tag2 = new Tag(2L, "2시간");
-        final AlternativeTagName alternativeTagName = new AlternativeTagName("1hour", tag);
-        // when
-        alternativeTagName.setTag(tag2);
-        // then
-        assertThat(tag.hasName(alternativeTagName.getValue())).isFalse();
-        assertThat(tag2.hasName(alternativeTagName.getValue())).isTrue();
-        assertThat(alternativeTagName.getTag()).isEqualTo(tag2);
-        assertThat(alternativeTagName.isDeleted()).isFalse();
-    }
-
     @DisplayName("단일 대체 이름 삭제")
     @Test
-    void delete() {
+    void deleteAlternativeName() {
         // given
-        final Tag tag = new Tag(1L, "1시간");
-        final AlternativeTagName alternativeName = new AlternativeTagName("1hour", tag);
+        Tag tag = new Tag(1L, "1시간");
+        AlternativeTagName alternativeName = new AlternativeTagName("1hour", tag);
+
         // when
+        assertThat(tag.isDeleted()).isFalse();
+        assertThat(alternativeName.isDeleted()).isFalse();
+
         tag.removeAlternativeName(alternativeName);
+
         // then
         assertThat(tag.hasName(alternativeName.getValue())).isFalse();
+        assertThat(alternativeName.isDeleted()).isTrue();
+    }
+
+    @DisplayName("태그를 삭제할 경우 대체 이름도 모두 삭제된다.")
+    @Test
+    void deleteTag() {
+        // given
+        Tag tag = new Tag(1L, "1시간");
+        AlternativeTagName alternativeName = new AlternativeTagName("1hour", tag);
+
+        // when
+        assertThat(tag.isDeleted()).isFalse();
+        assertThat(alternativeName.isDeleted()).isFalse();
+
+        tag.delete();
+
+        // then
+        assertThat(tag.isDeleted()).isTrue();
         assertThat(alternativeName.isDeleted()).isTrue();
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/domain/tag/TagTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/domain/tag/TagTest.java
@@ -93,6 +93,26 @@ class TagTest {
             .isExactlyInstanceOf(BabbleDuplicatedException.class);
     }
 
+    @DisplayName("태그 정보를 변경한다.")
+    @Test
+    void updateTag() {
+        Tag tag = new Tag(1L, "1시간");
+        AlternativeTagName alternativeTagName = new AlternativeTagName("1HOUR", tag);
+
+        String updateTagName = "2시간";
+        String updateAlternativeTagName = "2HOUR";
+
+        // when
+        Tag target = new Tag(updateTagName);
+        AlternativeTagName alternativeTargetTagName = new AlternativeTagName(updateAlternativeTagName, target);
+
+        tag.update(target);
+
+        // then
+        assertThat(tag.getName()).isEqualTo(updateTagName);
+        assertThat(tag.getAlternativeTagNames().getNames()).containsExactly(updateAlternativeTagName);
+    }
+
     @DisplayName("단일 대체 이름 변경")
     @Test
     void changeAlternativeName() {

--- a/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
@@ -10,6 +10,7 @@ import gg.babble.babble.dto.request.TagCreateRequest;
 import gg.babble.babble.dto.request.TagUpdateRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.exception.BabbleDuplicatedException;
+import gg.babble.babble.exception.BabbleNotFoundException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -95,23 +96,69 @@ public class TagServiceTest extends ApplicationTest {
         }
     }
 
-    @DisplayName("태그 정보를 수정한다.")
-    @Test
-    void updateTag() {
-        // given
-        Tag tag = tagRepository.save(new Tag("피터파커"));
-        AlternativeTagName alternativeTagName = new AlternativeTagName("노 웨이 홈", tag);
+    @DisplayName("태그 정보를 수정할 때")
+    @Nested
+    class UpdateTag {
 
-        String updateTagName = "피똥파커";
-        List<String> updateAlternativeTagNames = Arrays.asList("웨", "쳐", "피", "똥");
+        @DisplayName("id에 해당하는 태그가 존재하면 태그 정보를 수정한다.")
+        @Test
+        void updateTag() {
+            // given
+            Tag tag = tagRepository.save(new Tag("피터파커"));
+            AlternativeTagName alternativeTagName = new AlternativeTagName("노 웨이 홈", tag);
 
-        // when
-        TagUpdateRequest request = new TagUpdateRequest(updateTagName, updateAlternativeTagNames);
-        TagResponse response = tagService.updateTag(tag.getId(), request);
+            String updateTagName = "피똥파커";
+            List<String> updateAlternativeTagNames = Arrays.asList("웨", "쳐", "피", "똥");
 
-        // then
-        assertThat(response.getId()).isEqualTo(tag.getId());
-        assertThat(response.getName()).isEqualTo(updateTagName);
-        assertThat(response.getAlternativeNames()).isEqualTo(updateAlternativeTagNames);
+            // when
+            TagUpdateRequest request = new TagUpdateRequest(updateTagName, updateAlternativeTagNames);
+            TagResponse response = tagService.updateTag(tag.getId(), request);
+
+            // then
+            assertThat(response.getId()).isEqualTo(tag.getId());
+            assertThat(response.getName()).isEqualTo(updateTagName);
+            assertThat(response.getAlternativeNames()).isEqualTo(updateAlternativeTagNames);
+        }
+
+        @DisplayName("id에 해당하는 태그가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void updateTagException() {
+            // given
+            String updateTagName = "피똥파커";
+            List<String> updateAlternativeTagNames = Arrays.asList("웨", "쳐", "피", "똥");
+
+            // when, then
+            TagUpdateRequest request = new TagUpdateRequest(updateTagName, updateAlternativeTagNames);
+            assertThatThrownBy(() -> tagService.updateTag(Long.MAX_VALUE, request))
+                .isExactlyInstanceOf(BabbleNotFoundException.class);
+        }
+    }
+
+    @DisplayName("태그를 삭제할 때")
+    @Nested
+    class DeleteTag {
+
+        @DisplayName("id에 해당하는 태그가 존재하면 태그를 삭제한다.")
+        @Test
+        void updateTag() {
+            // given
+            Tag tag = tagRepository.save(new Tag("피터파커"));
+            AlternativeTagName alternativeTagName = new AlternativeTagName("노 웨이 홈", tag);
+
+            // when
+            assertThat(tagRepository.findByIdAndDeletedFalse(tag.getId())).isPresent();
+            tagService.deleteTag(tag.getId());
+
+            // then
+            assertThat(tagRepository.findByIdAndDeletedFalse(tag.getId())).isNotPresent();
+        }
+
+        @DisplayName("id에 해당하는 태그가 존재하지 않으면 예외가 발생한다.")
+        @Test
+        void updateTagException() {
+            // when, then
+            assertThatThrownBy(() -> tagService.deleteTag(Long.MAX_VALUE))
+                .isExactlyInstanceOf(BabbleNotFoundException.class);
+        }
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import gg.babble.babble.ApplicationTest;
+import gg.babble.babble.domain.tag.AlternativeTagName;
 import gg.babble.babble.domain.tag.Tag;
 import gg.babble.babble.dto.request.TagCreateRequest;
+import gg.babble.babble.dto.request.TagUpdateRequest;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.exception.BabbleDuplicatedException;
 import java.util.Arrays;
@@ -91,5 +93,25 @@ public class TagServiceTest extends ApplicationTest {
             assertThatThrownBy(() -> tagService.createTag(request))
                 .isExactlyInstanceOf(BabbleDuplicatedException.class);
         }
+    }
+
+    @DisplayName("태그 정보를 수정한다.")
+    @Test
+    void updateTag() {
+        // given
+        Tag tag = tagRepository.save(new Tag("피터파커"));
+        AlternativeTagName alternativeTagName = new AlternativeTagName("노 웨이 홈", tag);
+
+        String updateTagName = "피똥파커";
+        List<String> updateAlternativeTagNames = Arrays.asList("웨", "쳐", "피", "똥");
+
+        // when
+        TagUpdateRequest request = new TagUpdateRequest(updateTagName, updateAlternativeTagNames);
+        TagResponse response = tagService.updateTag(tag.getId(), request);
+
+        // then
+        assertThat(response.getId()).isEqualTo(tag.getId());
+        assertThat(response.getName()).isEqualTo(updateTagName);
+        assertThat(response.getAlternativeNames()).isEqualTo(updateAlternativeTagNames);
     }
 }

--- a/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/service/TagServiceTest.java
@@ -1,14 +1,18 @@
 package gg.babble.babble.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import gg.babble.babble.ApplicationTest;
 import gg.babble.babble.domain.tag.Tag;
+import gg.babble.babble.dto.request.TagCreateRequest;
 import gg.babble.babble.dto.response.TagResponse;
+import gg.babble.babble.exception.BabbleDuplicatedException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -39,5 +43,53 @@ public class TagServiceTest extends ApplicationTest {
         tagRepository.save(new Tag("실버"));
         tagRepository.save(new Tag("2시간"));
         tagRepository.save(new Tag("솔로랭크"));
+    }
+
+    @DisplayName("태그를 생성할 때")
+    @Nested
+    class createTag {
+
+        @DisplayName("태그 이름과 대체 이름간 중복이 없을 경우 정상적으로 생성된다.")
+        @Test
+        void createSuccess() {
+            // given
+            String tagName = "루트";
+            List<String> alternativeNames = Arrays.asList("피에 굶주린", "죽음의 사도", "어둠의다크니스 루트");
+            TagCreateRequest request = new TagCreateRequest(tagName, alternativeNames);
+
+            // when
+            TagResponse response = tagService.createTag(request);
+
+            // then
+            assertThat(response.getId()).isNotNull();
+            assertThat(response.getName()).isEqualTo(tagName);
+            assertThat(response.getAlternativeNames()).containsAll(alternativeNames);
+        }
+
+        @DisplayName("대체 이름간 중복이 존재할 경우 예외가 발생한다.")
+        @Test
+        void alternativeNameDuplicateException() {
+            // given
+            String tagName = "포츈";
+            List<String> alternativeNames = Arrays.asList("그가 화장실에 가면 기적이 일어난다", "토일렛 디버거 포츈", "토일렛 디버거 포츈");
+            TagCreateRequest request = new TagCreateRequest(tagName, alternativeNames);
+
+            // when, then
+            assertThatThrownBy(() -> tagService.createTag(request))
+                .isExactlyInstanceOf(BabbleDuplicatedException.class);
+        }
+
+        @DisplayName("태그 이름과 대체 이름간 중복이 존재할 경우 예외가 발생한다.")
+        @Test
+        void tagNameDuplicateWithAlternativeNameException() {
+            // given
+            String tagName = "와일더";
+            List<String> alternativeNames = Arrays.asList("크윽, 모두 도망쳐!!", "내 왼팔의 흑염룡이.. 크윽!!", "와일더");
+            TagCreateRequest request = new TagCreateRequest(tagName, alternativeNames);
+
+            // when, then
+            assertThatThrownBy(() -> tagService.createTag(request))
+                .isExactlyInstanceOf(BabbleDuplicatedException.class);
+        }
     }
 }

--- a/back/babble/src/test/resources/websocket-context.sql
+++ b/back/babble/src/test/resources/websocket-context.sql
@@ -14,7 +14,7 @@ insert into game (deleted, `name`) values (false, 'game1');
 insert into game_images(game_id, game_image) values ((select id from game limit 1), '게임 이미지1');
 insert into game_images(game_id, game_image) values ((select id from game limit 1), '게임 이미지2');
 insert into game_images(game_id, game_image) values ((select id from game limit 1), '게임 이미지3');
-insert into tag (`name`) values ('tag1');
+insert into tag (`name`, deleted) values ('tag1', false);
 insert into user (avatar, nickname) values ('abc', '와일더');
 insert into user (avatar, nickname) values ('abc', '루트');
 insert into user (avatar, nickname) values ('abc', '포츈');


### PR DESCRIPTION
Closes #375 

## 🔥 구현 내용 요약
관리자 태그 CRUD 관련 API를 구현했습니다.
코드리뷰를 받으면서 백엔드 크루들의 의견을 종합해 결정을 내려야 할 것 같은 부분들에 대해 TODO 주석을 남겨두었습니다. 

## ☠  AlternativeTagName 논리적 삭제
AlternativeTagName에 isDeleted 필드가 존재하는 것을 확인했고, AlternativeTagNames 일급 컬렉션에서 
isDeleted 필드 값에 따라 원소를 관리할 수 있도록 논리적 삭제를 구현했습니다.

이 과정에서 제가 놓친 부분들이 있을 수 있을 것 같아
`AlternativeTagName.java` 57번 라인에 주석을 남겨두었습니다.

## ☠  Set 자료구조를 전부 List로
`AlternativeTagName`은 다른 엔티티들과 같이 `id` 필드를 통해 동등성 비교를 진행하므로 일급 컬렉션에서 `Set` 자료구조를 사용하면 
영속화가 진행되기 전 `id`를 부여받지 못한 `AlternativeTagName`들이 버려지는 문제를 확인했습니다.
이에 따라 `List`를 사용하도록 변경했습니다.

## ☠  ElementCollection 로 변경
현재 `AlternativeGameName`, `AlternativeTagName`은 모두 `Game`, `Tag`와 생명주기를 함께하는 엔티티들입니다.
그러나 별도로 생명주기를 가지면서 연관관계만 맺어주다보니 서비스 로직을 구현하는 중간중간 계속해서 혼란이 생기는 것 같습니다.
포츈이 `Game.images`에 사용했던 `@ElementCollection` 어노테이션을 도입하는 방향을 고려해봐야 할 것 같습니다.

## ☠  태그를 삭제할 때 대체 이름과 관계를 유지시킬 것인지?
우선 현재는 `Tag`나 `AlternativeTagName`이 삭제되어도 서로 맺은 관계를 끊지 않도록 구성해두었습니다.
논리적 삭제를 사용하는 이유가 기록을 남기기 위해서고, '어떤 엔티티끼리 관계를 맺었었나' 또한 유의미한 데이터라고 생각했습니다.
(그러나 `@ElementCollection`이 도입되면 버려질 개념 같고, 대체 이름 관계가 굳이 기록되어야 하는가에 대한 의문이 조금 생기긴 합니다.)

## ☠  Flyway V10
2021년 9월 16일 머지된 포츈 PR의 Flyway가 V8, 아직 머지되지 않은 와일더 PR의 Flyway가 V9 가 될 것 같아 V10으로 명명해두었습니다.