### PR TITLE
refactor: application-dev.yml 에서 데이터베이스 URL만 주석처리하도록 변경

### DIFF
--- a/back/babble/src/main/resources/application-dev.yml
+++ b/back/babble/src/main/resources/application-dev.yml
@@ -6,11 +6,10 @@ spring:
 # 도커 컨테이너의 IP가 변경될 때마다 'application-dev.yml' 파일에서 IP를 변경하는 것은 공수가 크므로,
 # 'application-dev.yml' 파일이 아닌 'EC2-babble-test' 내부 스크립트 파일로 데이터베이스 IP를 관리한다.
 # -------------------------------------------------------------------------------------
-#  datasource:
-#    url: jdbc:mariadb://{IP주소}:3306/babble
-#    driver-class-name: org.mariadb.jdbc.Driver
-#    username: babble
-# -------------------------------------------------------------------------------------
+  datasource:
+#   url: jdbc:mariadb://{IP주소}:3306/babble
+    driver-class-name: org.mariadb.jdbc.Driver
+    username: babble
 
   jpa:
     hibernate:


### PR DESCRIPTION
Datasource 관련 옵션 중 password 와 url을 제외한 옵션들은 application-dev.yml 에서 관리하도록 수정

Closes #

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약

## ☠ 트러블 슈팅
