### PR TITLE
feat: x-forwarded-for 헤더를 사용해서 IP를 확인하도록 수정

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/config/AdminAccessInterceptor.java
+++ b/back/babble/src/main/java/gg/babble/babble/config/AdminAccessInterceptor.java
@@ -2,12 +2,14 @@ package gg.babble.babble.config;
 
 import gg.babble.babble.service.auth.AdministratorService;
 import gg.babble.babble.util.UrlParser;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class AdminAccessInterceptor implements HandlerInterceptor {
 
+    private static final String X_FORWARDED_FOR_HEADER = "x-forwarded-for";
     private final AdministratorService administratorService;
 
     public AdminAccessInterceptor(final AdministratorService administratorService) {
@@ -17,10 +19,21 @@ public class AdminAccessInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
         if (needsAuthentication(request)) {
-            String clientIp = request.getRemoteAddr();
+            String clientIp = getClientIpFrom(request);
+
             administratorService.validateIp(clientIp);
         }
         return true;
+    }
+
+    private String getClientIpFrom(final HttpServletRequest request) {
+        String clientIp = request.getHeader(X_FORWARDED_FOR_HEADER);
+
+        if (Objects.isNull(clientIp)) {
+            clientIp = request.getRemoteAddr();
+        }
+
+        return clientIp;
     }
 
     private boolean needsAuthentication(final HttpServletRequest request) {

--- a/back/babble/src/main/java/gg/babble/babble/config/AdminAccessInterceptor.java
+++ b/back/babble/src/main/java/gg/babble/babble/config/AdminAccessInterceptor.java
@@ -20,7 +20,6 @@ public class AdminAccessInterceptor implements HandlerInterceptor {
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
         if (needsAuthentication(request)) {
             String clientIp = getClientIpFrom(request);
-
             administratorService.validateIp(clientIp);
         }
         return true;


### PR DESCRIPTION
## 🔥 구현 내용 요약

IP 검증할 때, nginx의 IP를 확인하고 있는 문제를 해결하기 위해서 x-forwarded-for 헤더를 확인하도록 수정합니다.
