### PR TITLE
fix: 이미지 목록 조회 시 발생하는 에러 수정

### DIFF
--- a/back/babble/src/main/java/gg/babble/babble/domain/repository/s3repository/AbstractS3Repository.java
+++ b/back/babble/src/main/java/gg/babble/babble/domain/repository/s3repository/AbstractS3Repository.java
@@ -2,13 +2,14 @@ package gg.babble.babble.domain.repository.s3repository;
 
 import gg.babble.babble.domain.repository.S3Repository;
 import java.net.URLConnection;
+import java.util.Objects;
 
 public abstract class AbstractS3Repository implements S3Repository {
 
     private static final String IMAGE_CONTENT_TYPE = "image";
 
     protected boolean isImageFile(final String fileName) {
-        final String contentType = URLConnection.guessContentTypeFromName(fileName);
-        return contentType.contains(IMAGE_CONTENT_TYPE);
+        String contentType = URLConnection.guessContentTypeFromName(fileName);
+        return Objects.nonNull(contentType) && contentType.contains(IMAGE_CONTENT_TYPE);
     }
 }


### PR DESCRIPTION
Closes #559
--

## 🔥 구현 내용 요약

`URLConnection.guessContentTypeFromName` 메서드에서 추측하지 못하는 파일의 종류이면 null 타입이 반환되는 문제가 있었습니다. 이를 해결하기위해 null 체크를 하도록 수정했습니다.
