### PR TITLE
refactor: 테스트용 EC2 인스턴스 분할에 따른 리팩토링

### DIFF
--- a/.github/workflows/back-release-deploy.yml
+++ b/.github/workflows/back-release-deploy.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: SCP 명령을 이용해 테스트용 서버로 jar 파일 전송
       working-directory: ./back/babble
-      run: scp ./build/libs/babble-0.0.1-SNAPSHOT.jar test:/home/ubuntu/was
+      run: scp ./build/libs/babble-0.0.1-SNAPSHOT.jar test-was:/home/ubuntu/deploy
 
     - name: SSH 명령을 통해 테스트용 서버 접속 후 jar 파일 실행
-      run: ssh test "cd was; /home/ubuntu/was/deploy.sh;"
+      run: ssh test-was "cd deploy; /home/ubuntu/deploy/deploy.sh;"

--- a/back/babble/src/main/resources/application-dev.yml
+++ b/back/babble/src/main/resources/application-dev.yml
@@ -1,14 +1,8 @@
 spring:
 
-# -------------------------------------------------------------------------------------
-# 개발 환경 'EC2-babble-test' 에서는 데이터베이스를 같은 인스턴스 내에서 도커 컨테이너로 관리하고 있다.
-# 데이터베이스 도커 컨테이너를 조작할 경우 도커 컨테이너의 IP가 변경될 가능성이 다분하다.
-# 도커 컨테이너의 IP가 변경될 때마다 'application-dev.yml' 파일에서 IP를 변경하는 것은 공수가 크므로,
-# 'application-dev.yml' 파일이 아닌 'EC2-babble-test' 내부 스크립트 파일로 데이터베이스 IP를 관리한다.
-# -------------------------------------------------------------------------------------
   datasource:
-#   url: jdbc:mariadb://{IP주소}:3306/babble
     driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://192.168.2.215:3306/babble
     username: babble
 
   jpa:


### PR DESCRIPTION
### TEST-WEB-SERVER
- bastion과 연결 완료
- namecheap 사이트에서 test-api 도메인으로 향하는 주소 `TEST` 에서 `TEST-WEB-SERVER`로 변경해두었음.
- 로깅 잘 되는거같음.
    
![image](https://user-images.githubusercontent.com/37354145/136073409-7f821449-15a7-493e-b792-e21a41b55859.png)

### TEST-WAS
- bastion과 연결 완료
- `CICD(github actions)` → `TEST-WAS` 자동배포를 위해 `CICD` 인스턴스 내부와 `TEST-WAS` 인스턴스 내부 연결 설정 완료
- `CICD` 배포 설정 변경에 따른 `release-deploy.yml` 파일 변경
- 데이터베이스 연결 설정 변경에 따른 `application-dev.yml` 파일 변경
  - 더 이상 기존 `TEST` 인스턴스처럼 데이터베이스 IP가 변경될 위험이 사라짐.
- `CICD`를 통한 배포까지 해보려 했으나, 02:30 기준 PR OK 싸인 넣어줄 사람 없어서 진행 안됨...
- `TEST-WAS`에서 git clone 받고 직접 빌드 후 도커에 올려서 연결 테스트는 해보았음. 

![image](https://user-images.githubusercontent.com/37354145/136073380-04ef079f-c0f6-4003-8aa7-ab9223c7a8b9.png)

### TEST-DB
- bastion과 연결 완료
- 계정 및 스키마 생성 완료
- 데이터베이스 쪽 설정은 크게 건드릴거 없을듯?
- 데이터베이스에 데이터만 채워넣으면 되는 상태.
  - 근데 너무 피곤해서 내일 하겠음..
    
### 그 외
- 로깅 관련 설정 건드릴거 많을듯..
  - 다행히 TEST-WEB-SERVER는 지가 알아서 로그 잘 찍어주는 중 
- EC2별 보안그룹 관련 설정도 몇 가지 빼먹은게 있을거 같음.
  - 문서화 해두었던 자료들 하나씩 확인하면서 빼먹은 설정 있는지 체크 필요해보임.