### PR TITLE
fix: 모바일에서 모달이 작아졌을 때 화면 구성 변경

### DIFF
--- a/front/src/components/Modal/Modal.scss
+++ b/front/src/components/Modal/Modal.scss
@@ -151,7 +151,19 @@
   }
 
   .modal-minimized-container {
-    width: 100%;
-    right: 0;
+    width: 6rem;
+    height: 6rem;
+    bottom: 4rem;
+    right: 1.5rem;
+    border-radius: 50%;
+    background-image: url('https://babble.gg/img/logos/white-babble-logo.png');
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 55%;
+
+    .close,
+    .maximize {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
<img width="364" alt="Screen Shot 2021-10-09 at 7 11 41 PM" src="https://user-images.githubusercontent.com/26598561/136653990-cfe424ba-6980-426b-961f-cabd7ccfdf72.png">

## 🔥 구현 내용 요약
모바일에서 모달이 작아졌을 때 화면 구성 변경

## ☠ 트러블 슈팅
없었습니다!