### PR TITLE
refactor: 모바일에서 로고 중앙에 위치하도록 변경

### DIFF
--- a/front/src/components/NavBar/NavBar.scss
+++ b/front/src/components/NavBar/NavBar.scss
@@ -14,9 +14,13 @@
   .navigation-container {
     padding: 1rem 0;
 
-    .page-layout a {
-      svg {
-        width: 8rem;
+    .page-layout {
+      align-items: center;
+
+      a {
+        svg {
+          width: 8rem;
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)
<img width="383" alt="Screen Shot 2021-10-12 at 2 01 24 AM" src="https://user-images.githubusercontent.com/26598561/136828005-3dda8054-ce34-4c78-85ff-1c471b97c381.png">

## 🔥 구현 내용 요약
모바일에서 로고가 중앙에 위치하도록 변경했습니당.

## ☠ 트러블 슈팅
