### PR TITLE
fix: 방 생성 페이지에서 이미지가 표시되지 않던 버그 수정

### DIFF
--- a/front/src/pages/MakeRoom/MakeRoom.js
+++ b/front/src/pages/MakeRoom/MakeRoom.js
@@ -51,7 +51,7 @@ const MakeRoom = ({ match }) => {
       const response = await axios.get(
         `${BASE_URL}/api/games/${gameId}/images`
       );
-      const image = response.data.image;
+      const image = response.data.images[0];
 
       setImageUrl(image);
     } catch (error) {


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약
- 방 생성 페이지에서 이미지가 표시되지 않던 버그 수정

## ☠ 트러블 슈팅
