### PR TITLE
도커 스웜을 이용한 스케일 아웃 구성

### DIFF
--- a/.github/workflows/back-main-deploy.yml
+++ b/.github/workflows/back-main-deploy.yml
@@ -39,10 +39,22 @@ jobs:
       working-directory: ./back/babble
       run: SPRING_PROFILES_ACTIVE=local ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}
 
-    - name: SCP 명령을 이용해 WAS 서버로 jar 파일 전송
-      working-directory: ./back/babble
-      run: scp ./build/libs/babble-0.0.1-SNAPSHOT.jar was:/home/ubuntu
+    - name: jar 파일 복사
+      working-directory: ./back
+      run: cp ./babble/build/libs/babble-0.0.1-SNAPSHOT.jar ./deploy/was
 
-    - name: SSH 명령을 통해 WAS 서버 접속 후 jar 파일 실행
-      run: ssh was "cd deploy; /home/ubuntu/deploy/deploy.sh"
+    - name: 도커 이미지 빌드
+      working-directory: ./back/deploy/was
+      run: docker build -t babble-was:latest .
+
+    - name: 도커 이미지 태그 추가
+      working-directory: ./back/deploy/was
+      run: docker tag babble-was:latest 2021babble/babble-was:latest
+
+    - name: 도커 이미지 배포
+      working-directory: ./back/deploy/was
+      run: docker push 2021babble/babble-was:latest
+    
+    - name: 도커 서비스 롤링 업데이트
+      run: ssh was-manager "docker pull 2021babble/babble-was:latest; docker service update --image 2021babble/babble-was:latest babble-was;"
       

--- a/.github/workflows/back-release-deploy.yml
+++ b/.github/workflows/back-release-deploy.yml
@@ -39,9 +39,22 @@ jobs:
       working-directory: ./back/babble
       run: SPRING_PROFILES_ACTIVE=local ./gradlew sonarqube -Dsonar.projectKey=babble-sonarqube -Dsonar.host.url=${{ secrets.SONARQUBE_SERVER_URL }} -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}
 
-    - name: SCP 명령을 이용해 테스트용 서버로 jar 파일 전송
-      working-directory: ./back/babble
-      run: scp ./build/libs/babble-0.0.1-SNAPSHOT.jar test-was:/home/ubuntu/deploy
+    - name: jar 파일 복사
+      working-directory: ./back
+      run: cp ./babble/build/libs/babble-0.0.1-SNAPSHOT.jar ./deploy/was
 
-    - name: SSH 명령을 통해 테스트용 서버 접속 후 jar 파일 실행
-      run: ssh test-was "cd deploy; /home/ubuntu/deploy/deploy.sh;"
+    - name: 도커 이미지 빌드
+      working-directory: ./back/deploy/was
+      run: docker build -t babble-was:latest .
+
+    - name: 도커 이미지 태그 추가
+      working-directory: ./back/deploy/was
+      run: docker tag babble-was:latest 2021babble/babble-was:latest
+
+    - name: 도커 이미지 배포
+      working-directory: ./back/deploy/was
+      run: docker push 2021babble/babble-was:latest
+    
+    - name: 도커 서비스 롤링 업데이트
+      run: ssh test-was-manager "docker pull 2021babble/babble-was:latest; docker service update --image 2021babble/babble-was:latest babble-was;"
+      

--- a/back/deploy/was/Dockerfile
+++ b/back/deploy/was/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:8
+COPY babble-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=${PROFILES_ACTIVE}", "-Dspring.datasource.password=${DATASOURCE_PASSWORD}", "-Dspring.redis.password=${REDIS_PASSWORD}", "-Duser.timezone=Asia/Seoul", "app.jar"]


### PR DESCRIPTION
Closes #547, #548

## 🔥 구현 내용 요약

![image](https://user-images.githubusercontent.com/4648244/138603907-bf49c691-504b-427b-ae1b-c014f80d5675.png)


- 서버를 여러대로 늘려 스케일 아웃을 적용했습니다. 기존의 was와 test-was인스턴스는 더 이상 사용하지 않습니다.

![image](https://user-images.githubusercontent.com/4648244/138603818-cf73dd00-a9e5-4a63-8e60-5b2ebcf2deb3.png)

![image](https://user-images.githubusercontent.com/4648244/138603835-6be65aac-7927-4b41-acad-8dfcbffdb96f.png)

- was 배포 방식을 jar 파일이 아닌 docker hub에 업로드 하는 방식으로 수정했습니다.

## ☠ 트러블 슈팅

내용이 많아 링크로 대체합니다.

<https://grizzled-birthday-2e4.notion.site/a3c3d77d7f9f410eb26cb92737d99029>