### PR TITLE
fix: 잘못되어있던 테스트 코드 삭제

### DIFF
--- a/back/babble/src/docs/custom-snippets/chat-room-connect/web-socket-response.adoc
+++ b/back/babble/src/docs/custom-snippets/chat-room-connect/web-socket-response.adoc
@@ -1,4 +1,4 @@
 [source,http,options="nowrap"]
 ----
-HTTP/1.1 200 OK
+HTTP/1.1 101 Switching Protocols
 ----

--- a/back/babble/src/test/java/gg/babble/babble/restdocs/websocket/ChattingTest.java
+++ b/back/babble/src/test/java/gg/babble/babble/restdocs/websocket/ChattingTest.java
@@ -16,9 +16,6 @@ import gg.babble.babble.dto.response.SessionsResponse;
 import gg.babble.babble.dto.response.TagResponse;
 import gg.babble.babble.dto.response.UserResponse;
 import gg.babble.babble.restdocs.AcceptanceTest;
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +28,6 @@ import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
@@ -77,19 +73,6 @@ public class ChattingTest extends AcceptanceTest {
         guest3 = 유저가_생성_됨("현구막");
 
         room = 방이_생성_됨(game.getId(), Collections.singletonList(tag.getId()), 4);
-    }
-
-    @DisplayName("웹 소켓 연결시도에 성공하면, 200 OK 상태코드를 받는다.")
-    @Test
-    void webSocketConnectTest() {
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-            .when()
-            .get("/connection")
-            .then().log().all()
-            .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     @DisplayName("1번방에 입장하면, 자신을 포함한 1번방의 유저 정보들을 돌려받는다.")


### PR DESCRIPTION
Closes #

## 😎 캡쳐본(프론트)

## 🔥 구현 내용 요약
- 웹소켓 연결시도시 200이 올바른 응답이라고 잘못 판단하는 테스트를 제거했습니다.
- **연결 성공시에는 101 응답코드를 받아야합니다.**
- 하지만 이부분은 RestAssured를 통해서 확인이 불가능합니다.
  - 웹소켓 연결시 필요한 헤더들을 직접 넣어주어 보았으나, 웹소켓 연결을 실패하는것을 확인했습니다. 

- 아래 다른 테스트에서 웹소켓 연결 자체도 같이 테스트가 되고 있다고 판단하여, 현재 테스트는 잘못된테스트이며, 추가적으로 개선할 방법을 찾을 필요성이 없다고 판단하여 제거했습니다.

## ☠ 트러블 슈팅

![image](https://user-images.githubusercontent.com/43930419/141695803-3af34e95-efa3-4ec7-8380-a8e41d62674e.png)

postman의 웹소켓 connect시 들어가는 헤더들을 비슷하게 본떠서, HTTP GET 요청으로 넣어보았으나 101을 반환받지 못했습니다.

