### PR TITLE
Hotfix: log4j 보안 이슈 해결

### DIFF
--- a/back/babble/gradle/wrapper/gradle-wrapper.properties
+++ b/back/babble/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,4 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+org.gradle.jvmargs=log4j2.formatMsgNoLookups=true


### PR DESCRIPTION
Closes #

## 😎 캡쳐본

https://www.cyberkendra.com/2021/12/worst-log4j-rce-zeroday-dropped-on.html?m=1

구버전 log4j 에 제로데이 취약점이 발견됐네요.
2.0 <= Apache log4j2 <= 2.14.1 사이가 영향을 받는 버전입니다.

RCE 공격을 받을 우려가 있습니다.
현재 저희서비스는 2.14.1 이므로 공격 대상안입니다.

![image](https://user-images.githubusercontent.com/43930419/145554220-9517e3bc-a8f4-4f24-9134-ce5980159e81.png)


## 🔥 구현 내용 요약

https://github.com/tangxiaofeng7/apache-log4j-poc#%E4%BF%AE%E5%A4%8D%E6%96%B9%E6%A1%88

JVM 옵션에 `-Dlog4j2.formatMsgNoLookups=true` 을 추가했습니다.

## ☠ 트러블 슈팅
