### PR TITLE
fix: log4j2 버전 업데이트

### DIFF
--- a/back/babble/build.gradle
+++ b/back/babble/build.gradle
@@ -11,6 +11,8 @@ group = 'gg.babble'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
+ext['log4j2.version'] = '2.15.0'
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor


### PR DESCRIPTION
log4j2 이슈에 따른 버전 업데이트 (2.15.0)
`log4j2.formatMsgNoLookups = true` 에 대해서는 포츈이 이미 진행해주셨음
